### PR TITLE
Relax generics boundaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,5 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = "1.0.69"
+num-iter = "0.1.43"
 num-traits = "0.2.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,4 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = "1.0.69"
-num-integer = "0.1.45"
 num-traits = "0.2.15"

--- a/src/board.rs
+++ b/src/board.rs
@@ -1,4 +1,4 @@
-use num_integer::Integer;
+use num_traits::{One, Zero};
 use std::collections::HashSet;
 use std::fmt;
 use std::hash::Hash;
@@ -10,7 +10,7 @@ pub type DefaultIndexType = i16;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Board<IndexType = DefaultIndexType>
 where
-    IndexType: Integer + Hash,
+    IndexType: Eq + Hash,
 {
     live_cells: HashSet<(IndexType, IndexType)>,
 }
@@ -19,7 +19,7 @@ where
 
 impl<IndexType> Board<IndexType>
 where
-    IndexType: Integer + Hash,
+    IndexType: Eq + Hash,
 {
     /// Creates an empty board.
     #[inline]
@@ -85,7 +85,7 @@ where
     ///
     pub fn bounding_box(&self) -> (IndexType, IndexType, IndexType, IndexType)
     where
-        IndexType: Copy,
+        IndexType: Copy + PartialOrd + Zero,
     {
         let mut iter = self.live_cells.iter();
         if let Some(&(init_x, init_y)) = iter.next() {
@@ -113,7 +113,7 @@ where
 
 impl<'a, IndexType> Board<IndexType>
 where
-    IndexType: Integer + Hash,
+    IndexType: Eq + Hash,
 {
     /// Creates a non-owning iterator over the series of immutable live cell positions on the board in arbitrary order.
     #[inline]
@@ -126,7 +126,7 @@ where
 
 impl<IndexType> Default for Board<IndexType>
 where
-    IndexType: Integer + Hash,
+    IndexType: Eq + Hash,
 {
     /// Same as new().
     #[inline]
@@ -137,7 +137,7 @@ where
 
 impl<IndexType> fmt::Display for Board<IndexType>
 where
-    IndexType: Integer + Hash + Copy,
+    IndexType: Eq + Hash + Copy + PartialOrd + Zero + One,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let (x_min, x_max, y_min, y_max) = self.bounding_box();
@@ -158,7 +158,7 @@ where
 
 impl<'a, IndexType> IntoIterator for &'a Board<IndexType>
 where
-    IndexType: Integer + Hash,
+    IndexType: Eq + Hash,
 {
     type Item = &'a (IndexType, IndexType);
     type IntoIter = std::collections::hash_set::Iter<'a, (IndexType, IndexType)>;
@@ -183,7 +183,7 @@ where
 
 impl<IndexType> IntoIterator for Board<IndexType>
 where
-    IndexType: Integer + Hash,
+    IndexType: Eq + Hash,
 {
     type Item = (IndexType, IndexType);
     type IntoIter = std::collections::hash_set::IntoIter<Self::Item>;
@@ -208,7 +208,7 @@ where
 
 impl<'a, IndexType> FromIterator<&'a (IndexType, IndexType)> for Board<IndexType>
 where
-    IndexType: Integer + Hash + Copy + 'a,
+    IndexType: Eq + Hash + Copy + 'a,
 {
     /// Conversion from a non-owning iterator over a series of &(IndexType, IndexType).
     /// Each item in the series represents an immutable reference of a live cell position.
@@ -233,7 +233,7 @@ where
 
 impl<IndexType> FromIterator<(IndexType, IndexType)> for Board<IndexType>
 where
-    IndexType: Integer + Hash,
+    IndexType: Eq + Hash,
 {
     /// Conversion from an owning iterator over a series of (IndexType, IndexType).
     /// Each item in the series represents a moved live cell position.
@@ -258,7 +258,7 @@ where
 
 impl<'a, IndexType> Extend<&'a (IndexType, IndexType)> for Board<IndexType>
 where
-    IndexType: Integer + Hash + Copy + 'a,
+    IndexType: Eq + Hash + Copy + 'a,
 {
     /// Extend the board with the contents of the specified non-owning iterator over the series of &(IndexType, IndexType).
     /// Each item in the series represents an immutable reference of a live cell position.
@@ -284,7 +284,7 @@ where
 
 impl<IndexType> Extend<(IndexType, IndexType)> for Board<IndexType>
 where
-    IndexType: Integer + Hash,
+    IndexType: Eq + Hash,
 {
     /// Extend the board with the contents of the specified owning iterator over the series of (IndexType, IndexType).
     /// Each item in the series represents a moved live cell position.

--- a/src/board.rs
+++ b/src/board.rs
@@ -90,20 +90,13 @@ where
     {
         let mut iter = self.live_cells.iter();
         if let Some(&(init_x, init_y)) = iter.next() {
-            iter.fold((init_x, init_x, init_y, init_y), |(mut x_min, mut x_max, mut y_min, mut y_max), &(x, y)| {
-                if x < x_min {
-                    x_min = x
-                };
-                if x > x_max {
-                    x_max = x
-                };
-                if y < y_min {
-                    y_min = y
-                };
-                if y > y_max {
-                    y_max = y
-                };
-                (x_min, x_max, y_min, y_max)
+            iter.fold((init_x, init_x, init_y, init_y), |(x_min, x_max, y_min, y_max), &(x, y)| {
+                (
+                    if x_min < x { x_min } else { x },
+                    if x_max > x { x_max } else { x },
+                    if y_min < y { y_min } else { y },
+                    if y_max > y { y_max } else { y },
+                )
             })
         } else {
             let zero = IndexType::zero();

--- a/src/board.rs
+++ b/src/board.rs
@@ -136,10 +136,7 @@ where
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let (x_min, x_max, y_min, y_max) = self.bounding_box();
         for y in range_inclusive(y_min, y_max) {
-            let mut line = String::new();
-            for x in range_inclusive(x_min, x_max) {
-                line.push(if self.get(x, y) { 'O' } else { '.' });
-            }
+            let line: String = range_inclusive(x_min, x_max).map(|x| if self.get(x, y) { 'O' } else { '.' }).collect();
             writeln!(f, "{line}")?;
         }
         Ok(())

--- a/src/board.rs
+++ b/src/board.rs
@@ -56,7 +56,6 @@ where
     /// assert_eq!(board.get(0, 0), true);
     /// ```
     ///
-    #[inline]
     pub fn set(&mut self, x: IndexType, y: IndexType, value: bool) {
         let pos = (x, y);
         if value {

--- a/src/board.rs
+++ b/src/board.rs
@@ -1,4 +1,5 @@
-use num_traits::{One, Zero};
+use num_iter::range_inclusive;
+use num_traits::{One, ToPrimitive, Zero};
 use std::collections::HashSet;
 use std::fmt;
 use std::hash::Hash;
@@ -137,20 +138,16 @@ where
 
 impl<IndexType> fmt::Display for Board<IndexType>
 where
-    IndexType: Eq + Hash + Copy + PartialOrd + Zero + One,
+    IndexType: Eq + Hash + Copy + PartialOrd + Zero + One + ToPrimitive,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let (x_min, x_max, y_min, y_max) = self.bounding_box();
-        let mut y = y_min;
-        while y <= y_max {
-            let mut x = x_min;
+        for y in range_inclusive(y_min, y_max) {
             let mut line = String::new();
-            while x <= x_max {
+            for x in range_inclusive(x_min, x_max) {
                 line.push(if self.get(x, y) { 'O' } else { '.' });
-                x = x + IndexType::one();
             }
             writeln!(f, "{line}")?;
-            y = y + IndexType::one();
         }
         Ok(())
     }

--- a/src/board.rs
+++ b/src/board.rs
@@ -1,5 +1,6 @@
 use num_iter::range_inclusive;
 use num_traits::{One, ToPrimitive, Zero};
+use std::collections::hash_set;
 use std::collections::HashSet;
 use std::fmt;
 use std::hash::Hash;
@@ -110,7 +111,7 @@ where
 {
     /// Creates a non-owning iterator over the series of immutable live cell positions on the board in arbitrary order.
     #[inline]
-    pub fn iter(&'a self) -> std::collections::hash_set::Iter<'a, (IndexType, IndexType)> {
+    pub fn iter(&'a self) -> hash_set::Iter<'a, (IndexType, IndexType)> {
         self.into_iter()
     }
 }
@@ -150,7 +151,7 @@ where
     IndexType: Eq + Hash,
 {
     type Item = &'a (IndexType, IndexType);
-    type IntoIter = std::collections::hash_set::Iter<'a, (IndexType, IndexType)>;
+    type IntoIter = hash_set::Iter<'a, (IndexType, IndexType)>;
 
     /// Creates a non-owning iterator over the series of immutable live cell positions on the board in arbitrary order.
     ///
@@ -175,7 +176,7 @@ where
     IndexType: Eq + Hash,
 {
     type Item = (IndexType, IndexType);
-    type IntoIter = std::collections::hash_set::IntoIter<Self::Item>;
+    type IntoIter = hash_set::IntoIter<Self::Item>;
 
     /// Creates an owning iterator over the series of moved live cell positions on the board in arbitrary order.
     ///

--- a/src/format/plaintext.rs
+++ b/src/format/plaintext.rs
@@ -1,5 +1,7 @@
 use anyhow::{bail, ensure, Result};
-use num_traits::{bounds::UpperBounded, One, Zero};
+use num_iter::range;
+use num_traits::bounds::UpperBounded;
+use num_traits::{One, ToPrimitive, Zero};
 use std::fmt;
 use std::io::{BufRead, BufReader, Read};
 
@@ -220,7 +222,7 @@ impl<IndexType> Plaintext<IndexType> {
 
 impl<IndexType> fmt::Display for Plaintext<IndexType>
 where
-    IndexType: Copy + Zero + One + PartialOrd,
+    IndexType: Copy + Zero + One + PartialOrd + ToPrimitive,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f, "!Name: {}", self.name())?;
@@ -231,21 +233,15 @@ where
             let mut prev_y = IndexType::zero();
             for item in &self.contents {
                 let (curr_y, xs) = item;
-                {
-                    let mut y = prev_y;
-                    while y < *curr_y {
-                        writeln!(f)?;
-                        y = y + IndexType::one();
-                    }
+                for _ in range(prev_y, *curr_y) {
+                    writeln!(f)?;
                 }
                 let line = {
                     let mut buf = String::new();
                     let mut prev_x = IndexType::zero();
                     for &curr_x in xs {
-                        let mut x = prev_x;
-                        while x < curr_x {
+                        for _ in range(prev_x, curr_x) {
                             buf.push('.');
-                            x = x + IndexType::one();
                         }
                         buf.push('O');
                         prev_x = curr_x + IndexType::one();

--- a/src/format/plaintext.rs
+++ b/src/format/plaintext.rs
@@ -93,8 +93,8 @@ impl<IndexType> PlaintextPartial<IndexType> {
                     return Ok(());
                 }
             }
-            let content = Self::parse_content_line(line)?;
             ensure!(self.lines < IndexType::max_value(), "The pattern contains too many lines");
+            let content = Self::parse_content_line(line)?;
             if !content.is_empty() {
                 self.contents.push((self.lines, content));
             }

--- a/src/format/plaintext.rs
+++ b/src/format/plaintext.rs
@@ -54,13 +54,17 @@ impl<IndexType> PlaintextPartial<IndexType> {
         IndexType: Copy + PartialOrd + Zero + One + UpperBounded,
     {
         let mut buf = Vec::new();
+        let mut reach_to_max = false;
         for (i, char) in range_from(IndexType::zero()).zip(line.chars()) {
+            ensure!(!reach_to_max, "The pattern contains too wide line");
             match char {
                 '.' => (),
                 'O' => buf.push(i),
                 _ => bail!("Invalid character found in the pattern"),
-            };
-            ensure!(i < IndexType::max_value(), "The pattern contains too wide line");
+            }
+            if i >= IndexType::max_value() {
+                reach_to_max = true;
+            }
         }
         Ok(buf)
     }

--- a/src/format/plaintext.rs
+++ b/src/format/plaintext.rs
@@ -51,7 +51,7 @@ impl<IndexType> PlaintextPartial<IndexType> {
     }
     fn parse_content_line(line: &str) -> Result<Vec<IndexType>>
     where
-        IndexType: Copy + Zero + One + PartialOrd + UpperBounded,
+        IndexType: Copy + PartialOrd + Zero + One + UpperBounded,
     {
         let mut buf = Vec::new();
         let mut i = IndexType::zero();
@@ -79,7 +79,7 @@ impl<IndexType> PlaintextPartial<IndexType> {
     }
     fn push(&mut self, line: &str) -> Result<()>
     where
-        IndexType: Copy + Zero + One + PartialOrd + UpperBounded,
+        IndexType: Copy + PartialOrd + Zero + One + UpperBounded,
     {
         if self.name.is_none() {
             let name = Self::parse_name_line(line)?;
@@ -122,7 +122,7 @@ impl<IndexType> Plaintext<IndexType> {
     ///
     pub fn new<R: Read>(read: R) -> Result<Self>
     where
-        IndexType: Copy + Zero + One + PartialOrd + UpperBounded,
+        IndexType: Copy + PartialOrd + Zero + One + UpperBounded,
     {
         let partial = {
             let mut buf = PlaintextPartial::new();
@@ -222,7 +222,7 @@ impl<IndexType> Plaintext<IndexType> {
 
 impl<IndexType> fmt::Display for Plaintext<IndexType>
 where
-    IndexType: Copy + Zero + One + PartialOrd + ToPrimitive,
+    IndexType: Copy + PartialOrd + Zero + One + ToPrimitive,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f, "!Name: {}", self.name())?;

--- a/src/format/plaintext.rs
+++ b/src/format/plaintext.rs
@@ -229,9 +229,9 @@ where
         }
         if !self.contents.is_empty() {
             let mut prev_y = IndexType::zero();
-            for item in &self.contents {
-                let (curr_y, xs) = item;
-                for _ in range(prev_y, *curr_y) {
+            for (curr_y, xs) in &self.contents {
+                let curr_y = *curr_y;
+                for _ in range(prev_y, curr_y) {
                     writeln!(f)?;
                 }
                 let line = {
@@ -247,7 +247,7 @@ where
                     buf
                 };
                 writeln!(f, "{line}")?;
-                prev_y = *curr_y + IndexType::one();
+                prev_y = curr_y + IndexType::one();
             }
         }
         Ok(())

--- a/src/format/plaintext.rs
+++ b/src/format/plaintext.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, ensure, Result};
-use num_iter::range;
+use num_iter::{range, range_from};
 use num_traits::bounds::UpperBounded;
 use num_traits::{One, ToPrimitive, Zero};
 use std::fmt;
@@ -54,15 +54,13 @@ impl<IndexType> PlaintextPartial<IndexType> {
         IndexType: Copy + PartialOrd + Zero + One + UpperBounded,
     {
         let mut buf = Vec::new();
-        let mut i = IndexType::zero();
-        for char in line.chars() {
+        for (i, char) in range_from(IndexType::zero()).zip(line.chars()) {
             match char {
                 '.' => (),
                 'O' => buf.push(i),
                 _ => bail!("Invalid character found in the pattern"),
             };
             ensure!(i < IndexType::max_value(), "The pattern contains too wide line");
-            i = i + IndexType::one();
         }
         Ok(buf)
     }

--- a/src/format/plaintext.rs
+++ b/src/format/plaintext.rs
@@ -105,7 +105,7 @@ impl<IndexType> PlaintextPartial<IndexType> {
 // Inherent methods
 
 impl<IndexType> Plaintext<IndexType> {
-    /// Creates from the specified implementor of Read, such as File or &[u8].
+    /// Creates from the specified implementor of Read, such as File or `&[u8]`.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Relax generics boundaries.

- IndexType of Board
  - before: Integer + Hash
  - after(base): Eq + Hash
  - after(in several methods): + Copy, PartialOrd, Zero, One, ToPrimitive
- IndexType of format::Plaintext
  - before: Integer + UpperBounded + Copy
  - after(base):  none
  - after(in several methods): + Copy, PartialOrd, Zero, One, UpperBounded, ToPrimitive