### PR TITLE
format::Plaintext: improve acceptance

### DIFF
--- a/examples/format_plaintext.rs
+++ b/examples/format_plaintext.rs
@@ -1,0 +1,32 @@
+use anyhow::{bail, Context, Result};
+use life_backend::format::Plaintext;
+use std::env;
+use std::fs::File;
+use std::path::Path;
+
+struct Config {
+    path_str: String,
+}
+
+impl Config {
+    fn new(mut args: env::Args) -> Result<Self> {
+        args.next();
+        let Some(path_str) = args.next() else {
+            bail!("Not enough arguments");
+        };
+        Ok(Self { path_str })
+    }
+}
+
+fn run(config: &Config) -> Result<()> {
+    let path = Path::new(&config.path_str);
+    let file = File::open(path).with_context(|| format!("Failed to open \"{}\"", path.display()))?;
+    let parser = Plaintext::<i16>::new(file)?;
+    println!("{parser}");
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let config = Config::new(env::args())?;
+    run(&config)
+}

--- a/src/format/plaintext.rs
+++ b/src/format/plaintext.rs
@@ -294,6 +294,14 @@ mod tests {
         test_new(pattern, &expected_name, &expected_comments, &expected_contents)
     }
     #[test]
+    fn test_new_no_header_but_comment() -> Result<()> {
+        let pattern = "!comment\n";
+        let expected_name = None;
+        let expected_comments = vec!["comment"];
+        let expected_contents: Vec<(TargetIndexType, _)> = Vec::new();
+        test_new(pattern, &expected_name, &expected_comments, &expected_contents)
+    }
+    #[test]
     fn test_new_header_comment() -> Result<()> {
         let pattern = concat!("!Name: test\n", "!comment\n");
         let expected_name = Some("test");

--- a/src/format/plaintext.rs
+++ b/src/format/plaintext.rs
@@ -235,26 +235,22 @@ where
                 let max = |acc, x| if acc > x { acc } else { x };
                 self.contents.iter().map(|(_, xs)| xs.iter().copied().fold(zero, max)).fold(zero, max)
             };
+            let pad_line = ".".repeat(range_inclusive(IndexType::zero(), max_x).count());
             let mut prev_y = IndexType::zero();
             for (curr_y, xs) in &self.contents {
                 let curr_y = *curr_y;
                 for _ in range(prev_y, curr_y) {
-                    let pad: String = ".".repeat(range_inclusive(IndexType::zero(), max_x).count());
-                    writeln!(f, "{pad}")?;
+                    writeln!(f, "{pad_line}")?;
                 }
                 let line = {
                     let mut buf = String::new();
                     let mut prev_x = IndexType::zero();
                     for &curr_x in xs {
-                        for _ in range(prev_x, curr_x) {
-                            buf.push('.');
-                        }
+                        buf.push_str(&pad_line[0..(range(prev_x, curr_x).count())]);
                         buf.push('O');
                         prev_x = curr_x + IndexType::one();
                     }
-                    for _ in range_inclusive(prev_x, max_x) {
-                        buf.push('.');
-                    }
+                    buf.push_str(&pad_line[0..(range_inclusive(prev_x, max_x).count())]);
                     buf
                 };
                 writeln!(f, "{line}")?;


### PR DESCRIPTION
Accept more .cells files, such as:

```
! comment
.O.
..O
OOO
```

This file violates the rule: the header line must start with "!Name: ", but such files are sometimes seen.