### PR TITLE
Bugfix: format::Plaintext allow duplicate header-like lines

### DIFF
--- a/src/format/plaintext.rs
+++ b/src/format/plaintext.rs
@@ -61,7 +61,7 @@ impl PlaintextParser {
         }
     }
     fn push(&mut self, line: &str) -> Result<()> {
-        if self.comments.is_empty() && self.lines == 0 {
+        if self.name.is_none() && self.comments.is_empty() && self.lines == 0 {
             if let Some(name) = Self::parse_name_line(line) {
                 self.name = Some(name.to_string());
                 return Ok(());

--- a/src/format/plaintext.rs
+++ b/src/format/plaintext.rs
@@ -325,6 +325,14 @@ mod tests {
         do_new_test_to_be_failed(pattern)
     }
     #[test]
+    fn test_new_duplicate_header() -> Result<()> {
+        let pattern = concat!("!Name: name0\n", "!Name: name1\n");
+        let expected_name = Some("name0");
+        let expected_comments = vec!["Name: name1"];
+        let expected_contents = Vec::new();
+        do_new_test_to_be_passed(pattern, &expected_name, &expected_comments, &expected_contents)
+    }
+    #[test]
     fn test_new_wrong_content_without_comment() {
         let pattern = concat!("!Name: test\n", "_\n");
         do_new_test_to_be_failed(pattern)


### PR DESCRIPTION
Make format::Plaintext to be allowed duplicate header-like lines.
An example pattern is below:

```text
!Name: name0
!Name: name1
!Name: name2
```

- First line `!Name: name0` is accepted as the header line
- Second line and third line are accepted as comment lines