### PR TITLE
Add format::PlaintextBuilder and format::RleBuilder

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -2,4 +2,5 @@ mod plaintext;
 mod rle;
 
 pub use plaintext::Plaintext;
+pub use plaintext::PlaintextBuilder;
 pub use rle::Rle;

--- a/src/format.rs
+++ b/src/format.rs
@@ -4,3 +4,4 @@ mod rle;
 pub use plaintext::Plaintext;
 pub use plaintext::PlaintextBuilder;
 pub use rle::Rle;
+pub use rle::RleBuilder;

--- a/src/format/plaintext.rs
+++ b/src/format/plaintext.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, ensure, Result};
+use anyhow::{anyhow, ensure, Result};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::io::{BufRead as _, BufReader, Read};
@@ -92,15 +92,14 @@ impl PlaintextParser {
         Self::parse_prefixed_line("!", line)
     }
     fn parse_content_line(line: &str) -> Result<Vec<usize>> {
-        let mut buf = Vec::new();
-        for (i, char) in line.chars().enumerate() {
-            match char {
-                '.' => (),
-                'O' => buf.push(i),
-                _ => bail!("Invalid character found in the pattern"),
-            }
-        }
-        Ok(buf)
+        line.chars()
+            .enumerate()
+            .filter_map(|(i, char)| match char {
+                '.' => None,
+                'O' => Some(Ok(i)),
+                _ => Some(Err(anyhow!("Invalid character found in the pattern"))),
+            })
+            .collect()
     }
     fn new() -> Self {
         Self {

--- a/src/format/plaintext.rs
+++ b/src/format/plaintext.rs
@@ -198,7 +198,7 @@ where
     /// # use life_backend::format::PlaintextBuilder;
     /// let pattern = [(1, 0), (0, 1)];
     /// let plaintext = pattern.iter().collect::<PlaintextBuilder>().name("foo").build().unwrap();
-    /// assert_eq!(plaintext.name(), Some(String::from("foo")));
+    /// assert_eq!(plaintext.name(), Some("foo".to_string()));
     /// ```
     ///
     /// # Errors

--- a/src/format/plaintext.rs
+++ b/src/format/plaintext.rs
@@ -614,7 +614,7 @@ mod tests {
         Ok(())
     }
     #[test]
-    fn test_blank_comment() -> Result<()> {
+    fn test_build_blank_comment() -> Result<()> {
         let pattern = [(1, 0), (0, 1)];
         let expected_name = None;
         let expected_comments = vec![""];

--- a/src/format/plaintext.rs
+++ b/src/format/plaintext.rs
@@ -151,6 +151,7 @@ where
     /// ```
     ///
     pub fn build(self) -> Plaintext {
+        let name = self.name.drain();
         let comments = match self.comment.drain() {
             Some(str) => str.lines().map(|s| s.to_string()).collect(),
             None => Vec::new(),
@@ -164,11 +165,7 @@ where
         for (_, xs) in &mut contents {
             xs.sort();
         }
-        Plaintext {
-            name: self.name.drain(),
-            comments,
-            contents,
-        }
+        Plaintext { name, comments, contents }
     }
 }
 

--- a/src/format/plaintext.rs
+++ b/src/format/plaintext.rs
@@ -219,7 +219,7 @@ where
     /// ```should_panic
     /// # use life_backend::format::PlaintextBuilder;
     /// let pattern = [(1, 0), (0, 1)];
-    /// let target = pattern.iter().collect::<PlaintextBuilder>().name("foo\nbar").build().unwrap();
+    /// let target = pattern.iter().collect::<PlaintextBuilder>().name("foo\nbar").build().unwrap(); // this unwrap will panic
     /// ```
     ///
     pub fn name(self, str: &str) -> PlaintextBuilder<PlaintextBuilderWithName, Comment> {

--- a/src/format/plaintext.rs
+++ b/src/format/plaintext.rs
@@ -144,7 +144,6 @@ where
     /// # Examples
     ///
     /// ```
-    /// # use life_backend::format::Plaintext;
     /// # use life_backend::format::PlaintextBuilder;
     /// let pattern = [(1, 0), (0, 1)];
     /// let plaintext = pattern.iter().collect::<PlaintextBuilder>().build();
@@ -178,7 +177,6 @@ where
     /// # Examples
     ///
     /// ```
-    /// # use life_backend::format::Plaintext;
     /// # use life_backend::format::PlaintextBuilder;
     /// let pattern = [(1, 0), (0, 1)];
     /// let plaintext = pattern.iter().collect::<PlaintextBuilder>().name("foo").build();
@@ -190,7 +188,6 @@ where
     /// Code that calls name() twice or more will fail at compile time.  For example:
     ///
     /// ```compile_fail
-    /// # use life_backend::format::Plaintext;
     /// # use life_backend::format::PlaintextBuilder;
     /// let pattern = [(1, 0), (0, 1)];
     /// let plaintext = pattern.iter().collect::<PlaintextBuilder>().name("foo").name("bar").build(); // Compile error
@@ -215,7 +212,6 @@ where
     /// # Examples
     ///
     /// ```
-    /// # use life_backend::format::Plaintext;
     /// # use life_backend::format::PlaintextBuilder;
     /// let pattern = [(1, 0), (0, 1)];
     /// let plaintext = pattern.iter().collect::<PlaintextBuilder>().comment("comment0\ncomment1").build();
@@ -229,7 +225,6 @@ where
     /// Code that calls comment() twice or more will fail at compile time.  For example:
     ///
     /// ```compile_fail
-    /// # use life_backend::format::Plaintext;
     /// # use life_backend::format::PlaintextBuilder;
     /// let pattern = [(1, 0), (0, 1)];
     /// let plaintext = pattern.iter().collect::<PlaintextBuilder>().comment("comment0").comment("comment1").build(); // Compile error
@@ -254,7 +249,6 @@ impl<'a> FromIterator<&'a (usize, usize)> for PlaintextBuilder<PlaintextBuilderN
     /// # Examples
     ///
     /// ```
-    /// # use life_backend::format::Plaintext;
     /// # use life_backend::format::PlaintextBuilder;
     /// let pattern = [(1, 0), (0, 1)];
     /// let builder = pattern.iter().collect::<PlaintextBuilder>();
@@ -281,7 +275,6 @@ impl FromIterator<(usize, usize)> for PlaintextBuilder<PlaintextBuilderNoName, P
     /// # Examples
     ///
     /// ```
-    /// # use life_backend::format::Plaintext;
     /// # use life_backend::format::PlaintextBuilder;
     /// let pattern = [(1, 0), (0, 1)];
     /// let builder = pattern.into_iter().collect::<PlaintextBuilder>();

--- a/src/format/plaintext.rs
+++ b/src/format/plaintext.rs
@@ -152,7 +152,7 @@ where
     pub fn build(self) -> Result<Plaintext> {
         let name = self.name.drain();
         if let Some(str) = &name {
-            ensure!(str.lines().count() <= 1, "the string passed by name() includes multiple lines");
+            ensure!(str.lines().count() <= 1, "the string passed by name(str) includes multiple lines");
         };
         let comments = match self.comment.drain() {
             Some(str) => {

--- a/src/format/plaintext.rs
+++ b/src/format/plaintext.rs
@@ -172,7 +172,7 @@ where
         });
         let contents_sorted = {
             let mut buf: Vec<_> = contents_group_by_y.into_iter().collect();
-            buf.sort_by(|(y0, _), (y1, _)| y0.partial_cmp(y1).unwrap()); // note: this unwrap never panic because <usize>.partial_cmp(<usize>) always returns Some(_)
+            buf.sort_by(|(y0, _), (y1, _)| y0.partial_cmp(y1).unwrap()); // this unwrap never panic because <usize>.partial_cmp(<usize>) always returns Some(_)
             for (_, xs) in &mut buf {
                 xs.sort();
             }
@@ -435,7 +435,7 @@ impl fmt::Display for Plaintext {
             writeln!(f, "!{}", line)?;
         }
         if !self.contents.is_empty() {
-            let max_x = self.contents.iter().flat_map(|(_, xs)| xs.iter()).copied().max().unwrap(); // note: this unwrap() never panic because flat_map() always returns at least one value under !self.contents.is_empty()
+            let max_x = self.contents.iter().flat_map(|(_, xs)| xs.iter()).copied().max().unwrap(); // this unwrap() never panic because flat_map() always returns at least one value under !self.contents.is_empty()
             let pad_line = ".".repeat(max_x + 1); // max_x + 1 never overflows because max_x < usize::MAX is guaranteed by the format
             let mut prev_y = 0;
             for (curr_y, xs) in &self.contents {

--- a/src/format/plaintext.rs
+++ b/src/format/plaintext.rs
@@ -146,10 +146,10 @@ where
     /// ```
     /// # use life_backend::format::PlaintextBuilder;
     /// let pattern = [(1, 0), (0, 1)];
-    /// let plaintext = pattern.iter().collect::<PlaintextBuilder>().build();
+    /// let plaintext = pattern.iter().collect::<PlaintextBuilder>().build().unwrap();
     /// ```
     ///
-    pub fn build(self) -> Plaintext {
+    pub fn build(self) -> Result<Plaintext> {
         let name = self.name.drain();
         let comments = match self.comment.drain() {
             Some(str) => str.lines().map(|s| s.to_string()).collect(),
@@ -164,7 +164,7 @@ where
         for (_, xs) in &mut contents {
             xs.sort();
         }
-        Plaintext { name, comments, contents }
+        Ok(Plaintext { name, comments, contents })
     }
 }
 
@@ -179,7 +179,7 @@ where
     /// ```
     /// # use life_backend::format::PlaintextBuilder;
     /// let pattern = [(1, 0), (0, 1)];
-    /// let plaintext = pattern.iter().collect::<PlaintextBuilder>().name("foo").build();
+    /// let plaintext = pattern.iter().collect::<PlaintextBuilder>().name("foo").build().unwrap();
     /// assert_eq!(plaintext.name(), Some(String::from("foo")));
     /// ```
     ///
@@ -190,7 +190,7 @@ where
     /// ```compile_fail
     /// # use life_backend::format::PlaintextBuilder;
     /// let pattern = [(1, 0), (0, 1)];
-    /// let plaintext = pattern.iter().collect::<PlaintextBuilder>().name("foo").name("bar").build(); // Compile error
+    /// let plaintext = pattern.iter().collect::<PlaintextBuilder>().name("foo").name("bar").build().unwrap(); // Compile error
     /// ```
     ///
     pub fn name(self, str: &str) -> PlaintextBuilder<PlaintextBuilderWithName, Comment> {
@@ -214,7 +214,7 @@ where
     /// ```
     /// # use life_backend::format::PlaintextBuilder;
     /// let pattern = [(1, 0), (0, 1)];
-    /// let plaintext = pattern.iter().collect::<PlaintextBuilder>().comment("comment0\ncomment1").build();
+    /// let plaintext = pattern.iter().collect::<PlaintextBuilder>().comment("comment0\ncomment1").build().unwrap();
     /// assert_eq!(plaintext.comments().len(), 2);
     /// assert_eq!(plaintext.comments()[0], "comment0");
     /// assert_eq!(plaintext.comments()[1], "comment1");
@@ -227,7 +227,7 @@ where
     /// ```compile_fail
     /// # use life_backend::format::PlaintextBuilder;
     /// let pattern = [(1, 0), (0, 1)];
-    /// let plaintext = pattern.iter().collect::<PlaintextBuilder>().comment("comment0").comment("comment1").build(); // Compile error
+    /// let plaintext = pattern.iter().collect::<PlaintextBuilder>().comment("comment0").comment("comment1").build().unwrap(); // Compile error
     /// ```
     ///
     pub fn comment(self, str: &str) -> PlaintextBuilder<Name, PlaintextBuilderWithComment> {
@@ -252,7 +252,7 @@ impl<'a> FromIterator<&'a (usize, usize)> for PlaintextBuilder<PlaintextBuilderN
     /// # use life_backend::format::PlaintextBuilder;
     /// let pattern = [(1, 0), (0, 1)];
     /// let builder = pattern.iter().collect::<PlaintextBuilder>();
-    /// let plaintext = builder.build();
+    /// let plaintext = builder.build().unwrap();
     /// ```
     ///
     fn from_iter<T>(iter: T) -> Self
@@ -278,7 +278,7 @@ impl FromIterator<(usize, usize)> for PlaintextBuilder<PlaintextBuilderNoName, P
     /// # use life_backend::format::PlaintextBuilder;
     /// let pattern = [(1, 0), (0, 1)];
     /// let builder = pattern.into_iter().collect::<PlaintextBuilder>();
-    /// let plaintext = builder.build();
+    /// let plaintext = builder.build().unwrap();
     /// ```
     ///
     fn from_iter<T>(iter: T) -> Self
@@ -555,7 +555,7 @@ mod tests {
         let expected_name = None;
         let expected_comments = Vec::new();
         let expected_contents = vec![(0, vec![1]), (1, vec![0])];
-        let target = pattern.iter().collect::<PlaintextBuilder>().build();
+        let target = pattern.iter().collect::<PlaintextBuilder>().build()?;
         do_check(&target, &expected_name, &expected_comments, &expected_contents);
         Ok(())
     }
@@ -565,7 +565,7 @@ mod tests {
         let expected_name = Some("test");
         let expected_comments = Vec::new();
         let expected_contents = vec![(0, vec![1]), (1, vec![0])];
-        let target = pattern.iter().collect::<PlaintextBuilder>().name("test").build();
+        let target = pattern.iter().collect::<PlaintextBuilder>().name("test").build()?;
         do_check(&target, &expected_name, &expected_comments, &expected_contents);
         Ok(())
     }
@@ -575,7 +575,7 @@ mod tests {
         let expected_name = None;
         let expected_comments = vec!["comment"];
         let expected_contents = vec![(0, vec![1]), (1, vec![0])];
-        let target = pattern.iter().collect::<PlaintextBuilder>().comment("comment").build();
+        let target = pattern.iter().collect::<PlaintextBuilder>().comment("comment").build()?;
         do_check(&target, &expected_name, &expected_comments, &expected_contents);
         Ok(())
     }
@@ -585,7 +585,7 @@ mod tests {
         let expected_name = None;
         let expected_comments = vec!["comment0", "comment1"];
         let expected_contents = vec![(0, vec![1]), (1, vec![0])];
-        let target = pattern.iter().collect::<PlaintextBuilder>().comment("comment0\ncomment1").build();
+        let target = pattern.iter().collect::<PlaintextBuilder>().comment("comment0\ncomment1").build()?;
         do_check(&target, &expected_name, &expected_comments, &expected_contents);
         Ok(())
     }
@@ -595,7 +595,7 @@ mod tests {
         let expected_name = Some("test");
         let expected_comments = vec!["comment"];
         let expected_contents = vec![(0, vec![1]), (1, vec![0])];
-        let target = pattern.iter().collect::<PlaintextBuilder>().name("test").comment("comment").build();
+        let target = pattern.iter().collect::<PlaintextBuilder>().name("test").comment("comment").build()?;
         do_check(&target, &expected_name, &expected_comments, &expected_contents);
         Ok(())
     }

--- a/src/format/plaintext.rs
+++ b/src/format/plaintext.rs
@@ -169,12 +169,19 @@ where
             acc.entry(y).or_insert_with(Vec::new).push(x);
             acc
         });
-        let mut contents: Vec<_> = contents_group_by_y.into_iter().collect();
-        contents.sort_by(|(y0, _), (y1, _)| y0.partial_cmp(y1).unwrap()); // note: this unwrap never panic because <usize>.partial_cmp(<usize>) always returns Some(_)
-        for (_, xs) in &mut contents {
-            xs.sort();
-        }
-        Ok(Plaintext { name, comments, contents })
+        let contents_sorted = {
+            let mut buf: Vec<_> = contents_group_by_y.into_iter().collect();
+            buf.sort_by(|(y0, _), (y1, _)| y0.partial_cmp(y1).unwrap()); // note: this unwrap never panic because <usize>.partial_cmp(<usize>) always returns Some(_)
+            for (_, xs) in &mut buf {
+                xs.sort();
+            }
+            buf
+        };
+        Ok(Plaintext {
+            name,
+            comments,
+            contents: contents_sorted,
+        })
     }
 }
 

--- a/src/format/plaintext.rs
+++ b/src/format/plaintext.rs
@@ -152,7 +152,7 @@ where
     pub fn build(self) -> Result<Plaintext> {
         let name = self.name.drain();
         if let Some(str) = &name {
-            ensure!(str.lines().count() <= 1, "str passed by name(str) includes multiple lines");
+            ensure!(str.lines().count() <= 1, "the string passed by name() includes multiple lines");
         };
         let comments = match self.comment.drain() {
             Some(str) => {
@@ -288,7 +288,7 @@ impl<'a> FromIterator<&'a (usize, usize)> for PlaintextBuilder<PlaintextBuilderN
 
 impl FromIterator<(usize, usize)> for PlaintextBuilder<PlaintextBuilderNoName, PlaintextBuilderNoComment> {
     /// Conversion from an owning iterator over a series of (usize, usize).
-    /// Each item in the series represents an immutable reference of a live cell position.
+    /// Each item in the series represents a moved live cell position.
     ///
     /// # Examples
     ///

--- a/src/format/plaintext.rs
+++ b/src/format/plaintext.rs
@@ -207,7 +207,7 @@ impl<Name> PlaintextBuilder<Name, PlaintextBuilderNoComment>
 where
     Name: PlaintextBuilderName,
 {
-    /// Set the comment.
+    /// Set the comment.  If the argument includes newlines, the instance of Plaintext built by build() includes multiple comment lines.
     ///
     /// # Examples
     ///

--- a/src/format/plaintext.rs
+++ b/src/format/plaintext.rs
@@ -36,7 +36,7 @@ where
     contents: HashSet<(usize, usize)>,
 }
 
-// Traits and Types for PlaintextBuilder's typestate
+// Traits and types for PlaintextBuilder's typestate
 pub trait PlaintextBuilderName {
     fn drain(self) -> Option<String>;
 }

--- a/src/format/plaintext.rs
+++ b/src/format/plaintext.rs
@@ -155,7 +155,14 @@ where
             ensure!(str.lines().count() <= 1, "str passed by name(str) includes multiple lines");
         };
         let comments = match self.comment.drain() {
-            Some(str) => str.lines().map(|s| s.to_string()).collect(),
+            Some(str) => {
+                let buf: Vec<_> = str.lines().map(|s| s.to_string()).collect();
+                if buf.is_empty() {
+                    vec![String::new()]
+                } else {
+                    buf
+                }
+            }
             None => Vec::new(),
         };
         let contents_group_by_y = self.contents.into_iter().fold(HashMap::new(), |mut acc, (x, y)| {
@@ -581,7 +588,7 @@ mod tests {
         Ok(())
     }
     #[test]
-    fn test_build_empty_name() -> Result<()> {
+    fn test_build_blank_name() -> Result<()> {
         let pattern = [(1, 0), (0, 1)];
         let expected_name = Some("");
         let expected_comments = Vec::new();
@@ -603,6 +610,16 @@ mod tests {
         let expected_comments = vec!["comment"];
         let expected_contents = vec![(0, vec![1]), (1, vec![0])];
         let target = pattern.iter().collect::<PlaintextBuilder>().comment("comment").build()?;
+        do_check(&target, &expected_name, &expected_comments, &expected_contents);
+        Ok(())
+    }
+    #[test]
+    fn test_blank_comment() -> Result<()> {
+        let pattern = [(1, 0), (0, 1)];
+        let expected_name = None;
+        let expected_comments = vec![""];
+        let expected_contents = vec![(0, vec![1]), (1, vec![0])];
+        let target = pattern.iter().collect::<PlaintextBuilder>().comment("").build()?;
         do_check(&target, &expected_name, &expected_comments, &expected_contents);
         Ok(())
     }

--- a/src/format/plaintext.rs
+++ b/src/format/plaintext.rs
@@ -139,7 +139,7 @@ where
     Name: PlaintextBuilderName,
     Comment: PlaintextBuilderComment,
 {
-    // Builds the Plaintext.
+    /// Builds the Plaintext.
     ///
     /// # Examples
     ///

--- a/src/format/plaintext.rs
+++ b/src/format/plaintext.rs
@@ -155,7 +155,7 @@ where
         };
         let comments = match self.comment.drain() {
             Some(str) => {
-                let buf: Vec<_> = str.lines().map(|s| s.to_string()).collect();
+                let buf: Vec<_> = str.lines().map(String::from).collect();
                 if buf.is_empty() {
                     // buf is empty only if str == "" || str == "\n"
                     vec![String::new()]

--- a/src/format/plaintext.rs
+++ b/src/format/plaintext.rs
@@ -445,7 +445,7 @@ impl fmt::Display for Plaintext {
                 let line = {
                     let mut buf = String::new();
                     let mut prev_x = 0;
-                    for &curr_x in xs {
+                    for curr_x in xs {
                         buf.push_str(&pad_line[0..(curr_x - prev_x)]);
                         buf.push('O');
                         prev_x = curr_x + 1;

--- a/src/format/plaintext.rs
+++ b/src/format/plaintext.rs
@@ -158,6 +158,7 @@ where
             Some(str) => {
                 let buf: Vec<_> = str.lines().map(|s| s.to_string()).collect();
                 if buf.is_empty() {
+                    // buf is empty only if str == "" || str == "\n"
                     vec![String::new()]
                 } else {
                     buf

--- a/src/format/plaintext.rs
+++ b/src/format/plaintext.rs
@@ -188,6 +188,17 @@ where
     /// assert_eq!(plaintext.name(), Some(String::from("foo")));
     /// ```
     ///
+    /// # Note
+    ///
+    /// Code that calls name() twice or more will fail at compile time.  For example:
+    ///
+    /// ```compile_fail
+    /// # use life_backend::format::Plaintext;
+    /// # use life_backend::format::PlaintextBuilder;
+    /// let pattern = [(1, 0), (0, 1)];
+    /// let plaintext = pattern.iter().collect::<PlaintextBuilder>().name("foo").name("bar").build(); // Compile will fail
+    /// ```
+    ///
     pub fn name(self, str: &str) -> PlaintextBuilder<PlaintextBuilderWithName, Comment> {
         let name = PlaintextBuilderWithName(str.to_string());
         PlaintextBuilder::<PlaintextBuilderWithName, Comment> {
@@ -214,6 +225,17 @@ where
     /// assert_eq!(plaintext.comments().len(), 2);
     /// assert_eq!(plaintext.comments()[0], "comment0");
     /// assert_eq!(plaintext.comments()[1], "comment1");
+    /// ```
+    ///
+    /// # Note
+    ///
+    /// Code that calls comment() twice or more will fail at compile time.  For example:
+    ///
+    /// ```compile_fail
+    /// # use life_backend::format::Plaintext;
+    /// # use life_backend::format::PlaintextBuilder;
+    /// let pattern = [(1, 0), (0, 1)];
+    /// let plaintext = pattern.iter().collect::<PlaintextBuilder>().comment("comment0").comment("comment1").build(); // Compile will fail
     /// ```
     ///
     pub fn comment(self, str: &str) -> PlaintextBuilder<Name, PlaintextBuilderWithComment> {

--- a/src/format/plaintext.rs
+++ b/src/format/plaintext.rs
@@ -145,7 +145,7 @@ where
     /// ```
     /// # use life_backend::format::PlaintextBuilder;
     /// let pattern = [(1, 0), (0, 1)];
-    /// let plaintext = pattern.iter().collect::<PlaintextBuilder>().build().unwrap();
+    /// let target = pattern.iter().collect::<PlaintextBuilder>().build().unwrap();
     /// ```
     ///
     pub fn build(self) -> Result<Plaintext> {
@@ -196,8 +196,8 @@ where
     /// ```
     /// # use life_backend::format::PlaintextBuilder;
     /// let pattern = [(1, 0), (0, 1)];
-    /// let plaintext = pattern.iter().collect::<PlaintextBuilder>().name("foo").build().unwrap();
-    /// assert_eq!(plaintext.name(), Some("foo".to_string()));
+    /// let target = pattern.iter().collect::<PlaintextBuilder>().name("foo").build().unwrap();
+    /// assert_eq!(target.name(), Some("foo".to_string()));
     /// ```
     ///
     /// # Errors
@@ -207,7 +207,7 @@ where
     /// ```compile_fail
     /// # use life_backend::format::PlaintextBuilder;
     /// let pattern = [(1, 0), (0, 1)];
-    /// let plaintext = pattern.iter().collect::<PlaintextBuilder>().name("foo").name("bar").build().unwrap(); // Compile error
+    /// let target = pattern.iter().collect::<PlaintextBuilder>().name("foo").name("bar").build().unwrap(); // Compile error
     /// ```
     ///
     /// build() returns an error if the string passed by name(str) includes multiple lines.  For example:
@@ -215,7 +215,7 @@ where
     /// ```should_panic
     /// # use life_backend::format::PlaintextBuilder;
     /// let pattern = [(1, 0), (0, 1)];
-    /// let plaintext = pattern.iter().collect::<PlaintextBuilder>().name("foo\nbar").build().unwrap();
+    /// let target = pattern.iter().collect::<PlaintextBuilder>().name("foo\nbar").build().unwrap();
     /// ```
     ///
     pub fn name(self, str: &str) -> PlaintextBuilder<PlaintextBuilderWithName, Comment> {
@@ -239,10 +239,10 @@ where
     /// ```
     /// # use life_backend::format::PlaintextBuilder;
     /// let pattern = [(1, 0), (0, 1)];
-    /// let plaintext = pattern.iter().collect::<PlaintextBuilder>().comment("comment0\ncomment1").build().unwrap();
-    /// assert_eq!(plaintext.comments().len(), 2);
-    /// assert_eq!(plaintext.comments()[0], "comment0");
-    /// assert_eq!(plaintext.comments()[1], "comment1");
+    /// let target = pattern.iter().collect::<PlaintextBuilder>().comment("comment0\ncomment1").build().unwrap();
+    /// assert_eq!(target.comments().len(), 2);
+    /// assert_eq!(target.comments()[0], "comment0");
+    /// assert_eq!(target.comments()[1], "comment1");
     /// ```
     ///
     /// # Errors
@@ -252,7 +252,7 @@ where
     /// ```compile_fail
     /// # use life_backend::format::PlaintextBuilder;
     /// let pattern = [(1, 0), (0, 1)];
-    /// let plaintext = pattern.iter().collect::<PlaintextBuilder>().comment("comment0").comment("comment1").build().unwrap(); // Compile error
+    /// let target = pattern.iter().collect::<PlaintextBuilder>().comment("comment0").comment("comment1").build().unwrap(); // Compile error
     /// ```
     ///
     pub fn comment(self, str: &str) -> PlaintextBuilder<Name, PlaintextBuilderWithComment> {
@@ -277,7 +277,7 @@ impl<'a> FromIterator<&'a (usize, usize)> for PlaintextBuilder<PlaintextBuilderN
     /// # use life_backend::format::PlaintextBuilder;
     /// let pattern = [(1, 0), (0, 1)];
     /// let builder = pattern.iter().collect::<PlaintextBuilder>();
-    /// let plaintext = builder.build().unwrap();
+    /// let target = builder.build().unwrap();
     /// ```
     ///
     fn from_iter<T>(iter: T) -> Self
@@ -303,7 +303,7 @@ impl FromIterator<(usize, usize)> for PlaintextBuilder<PlaintextBuilderNoName, P
     /// # use life_backend::format::PlaintextBuilder;
     /// let pattern = [(1, 0), (0, 1)];
     /// let builder = pattern.into_iter().collect::<PlaintextBuilder>();
-    /// let plaintext = builder.build().unwrap();
+    /// let target = builder.build().unwrap();
     /// ```
     ///
     fn from_iter<T>(iter: T) -> Self

--- a/src/format/plaintext.rs
+++ b/src/format/plaintext.rs
@@ -186,7 +186,7 @@ where
     /// assert_eq!(plaintext.name(), Some(String::from("foo")));
     /// ```
     ///
-    /// # Note
+    /// # Errors
     ///
     /// Code that calls name() twice or more will fail at compile time.  For example:
     ///
@@ -194,6 +194,14 @@ where
     /// # use life_backend::format::PlaintextBuilder;
     /// let pattern = [(1, 0), (0, 1)];
     /// let plaintext = pattern.iter().collect::<PlaintextBuilder>().name("foo").name("bar").build().unwrap(); // Compile error
+    /// ```
+    ///
+    /// build() returns an error if the string passed by name(str) includes multiple lines.  For example:
+    ///
+    /// ```should_panic
+    /// # use life_backend::format::PlaintextBuilder;
+    /// let pattern = [(1, 0), (0, 1)];
+    /// let plaintext = pattern.iter().collect::<PlaintextBuilder>().name("foo\nbar").build().unwrap();
     /// ```
     ///
     pub fn name(self, str: &str) -> PlaintextBuilder<PlaintextBuilderWithName, Comment> {
@@ -223,7 +231,7 @@ where
     /// assert_eq!(plaintext.comments()[1], "comment1");
     /// ```
     ///
-    /// # Note
+    /// # Errors
     ///
     /// Code that calls comment() twice or more will fail at compile time.  For example:
     ///

--- a/src/format/plaintext.rs
+++ b/src/format/plaintext.rs
@@ -340,14 +340,11 @@ impl Plaintext {
     where
         R: Read,
     {
-        let parser = {
-            let mut buf = PlaintextParser::new();
-            for line in BufReader::new(read).lines() {
-                let line = line?;
-                buf.push(&line)?;
-            }
-            buf
-        };
+        let parser = BufReader::new(read).lines().try_fold(PlaintextParser::new(), |mut buf, line| {
+            let line = line?;
+            buf.push(&line)?;
+            Ok::<_, anyhow::Error>(buf)
+        })?;
         Ok(Self {
             name: parser.name,
             comments: parser.comments,

--- a/src/format/plaintext.rs
+++ b/src/format/plaintext.rs
@@ -36,7 +36,7 @@ where
     contents: HashSet<(usize, usize)>,
 }
 
-// Internal traits and types for PlaintextBuilder's typestate
+// Traits and Types for PlaintextBuilder's typestate
 pub trait PlaintextBuilderName {
     fn drain(self) -> Option<String>;
 }
@@ -196,7 +196,7 @@ where
     /// # use life_backend::format::Plaintext;
     /// # use life_backend::format::PlaintextBuilder;
     /// let pattern = [(1, 0), (0, 1)];
-    /// let plaintext = pattern.iter().collect::<PlaintextBuilder>().name("foo").name("bar").build(); // Compile will fail
+    /// let plaintext = pattern.iter().collect::<PlaintextBuilder>().name("foo").name("bar").build(); // Compile error
     /// ```
     ///
     pub fn name(self, str: &str) -> PlaintextBuilder<PlaintextBuilderWithName, Comment> {
@@ -235,7 +235,7 @@ where
     /// # use life_backend::format::Plaintext;
     /// # use life_backend::format::PlaintextBuilder;
     /// let pattern = [(1, 0), (0, 1)];
-    /// let plaintext = pattern.iter().collect::<PlaintextBuilder>().comment("comment0").comment("comment1").build(); // Compile will fail
+    /// let plaintext = pattern.iter().collect::<PlaintextBuilder>().comment("comment0").comment("comment1").build(); // Compile error
     /// ```
     ///
     pub fn comment(self, str: &str) -> PlaintextBuilder<Name, PlaintextBuilderWithComment> {

--- a/src/format/plaintext.rs
+++ b/src/format/plaintext.rs
@@ -220,7 +220,7 @@ where
     ///
     pub fn name(self, str: &str) -> PlaintextBuilder<PlaintextBuilderWithName, Comment> {
         let name = PlaintextBuilderWithName(str.to_string());
-        PlaintextBuilder::<PlaintextBuilderWithName, Comment> {
+        PlaintextBuilder {
             name,
             comment: self.comment,
             contents: self.contents,
@@ -257,7 +257,7 @@ where
     ///
     pub fn comment(self, str: &str) -> PlaintextBuilder<Name, PlaintextBuilderWithComment> {
         let comment = PlaintextBuilderWithComment(str.to_string());
-        PlaintextBuilder::<Name, PlaintextBuilderWithComment> {
+        PlaintextBuilder {
             name: self.name,
             comment,
             contents: self.contents,

--- a/src/format/plaintext.rs
+++ b/src/format/plaintext.rs
@@ -2,7 +2,12 @@ use anyhow::{bail, Result};
 use std::fmt;
 use std::io::{BufRead, BufReader, Read};
 
-/// A representation for Plaintext file format, described in <https://conwaylife.com/wiki/Plaintext>.
+/// A representation for Plaintext file format.
+///
+/// The detail of this format is described in:
+///
+/// - [Plaintext - LifeWiki](https://conwaylife.com/wiki/Plaintext)
+///
 #[derive(Debug, Clone)]
 pub struct Plaintext {
     name: Option<String>,

--- a/src/format/rle.rs
+++ b/src/format/rle.rs
@@ -2,7 +2,13 @@ use anyhow::{bail, ensure, Result};
 use std::fmt;
 use std::io::{BufRead, BufReader, Read};
 
-/// A representation for RLE file format, described in <https://conwaylife.com/wiki/Run_Length_Encoded> and <https://golly.sourceforge.net/Help/formats.html#rle>.
+/// A representation for RLE file format.
+///
+/// The detail of this format is described in:
+///
+/// - [Run Length Encoded - LifeWiki](https://conwaylife.com/wiki/Run_Length_Encoded)
+/// - [Golly Help: File Formats > Extended RLE format](https://golly.sourceforge.net/Help/formats.html#rle)
+///
 #[derive(Debug, Clone)]
 pub struct Rle {
     comments: Vec<String>,

--- a/src/format/rle.rs
+++ b/src/format/rle.rs
@@ -436,9 +436,10 @@ where
     /// ```
     /// # use life_backend::format::RleBuilder;
     /// let pattern = [(1, 0), (0, 1)];
-    /// let rle = pattern.iter().collect::<RleBuilder>().comment("foo").build().unwrap();
-    /// assert_eq!(rle.comments().len(), 1);
-    /// assert_eq!(rle.comments()[0], String::from("#C foo"));
+    /// let rle = pattern.iter().collect::<RleBuilder>().comment("comment0\ncomment1").build().unwrap();
+    /// assert_eq!(rle.comments().len(), 2);
+    /// assert_eq!(rle.comments()[0], String::from("#C comment0"));
+    /// assert_eq!(rle.comments()[1], String::from("#C comment1"));
     /// ```
     ///
     /// # Errors
@@ -448,7 +449,7 @@ where
     /// ```compile_fail
     /// # use life_backend::format::RleBuilder;
     /// let pattern = [(1, 0), (0, 1)];
-    /// let rle = pattern.iter().collect::<RleBuilder>().comment("foo").comment("bar").build().unwrap(); // Compile error
+    /// let rle = pattern.iter().collect::<RleBuilder>().comment("comment0").comment("comment1").build().unwrap(); // Compile error
     /// ```
     ///
     pub fn comment(self, str: &str) -> RleBuilder<Name, Created, RleBuilderWithComment> {

--- a/src/format/rle.rs
+++ b/src/format/rle.rs
@@ -348,7 +348,7 @@ where
     /// ```should_panic
     /// # use life_backend::format::RleBuilder;
     /// let pattern = [(1, 0), (0, 1)];
-    /// let target = pattern.iter().collect::<RleBuilder>().name("foo\nbar").build().unwrap();
+    /// let target = pattern.iter().collect::<RleBuilder>().name("foo\nbar").build().unwrap(); // this unwrap will panic
     /// ```
     ///
     pub fn name(self, str: &str) -> RleBuilder<RleBuilderWithName, Created, Comment> {

--- a/src/format/rle.rs
+++ b/src/format/rle.rs
@@ -282,11 +282,10 @@ where
             if let Some(str) = &name {
                 ensure!(str.lines().count() <= 1, "the string passed by name(str) includes multiple lines");
             }
-            let mut buf = Vec::new();
-            for (str, prefix) in [(name, "#N"), (self.created.drain(), "#O"), (self.comment.drain(), "#C")] {
-                buf.extend(parse_to_comments(str, prefix).into_iter());
-            }
-            buf
+            [(name, "#N"), (self.created.drain(), "#O"), (self.comment.drain(), "#C")]
+                .into_iter()
+                .flat_map(|(str, prefix)| parse_to_comments(str, prefix).into_iter())
+                .collect::<Vec<_>>()
         };
         let contents_group_by_y = self.contents.into_iter().fold(HashMap::new(), |mut acc, (x, y)| {
             acc.entry(y).or_insert_with(Vec::new).push(x);

--- a/src/format/rle.rs
+++ b/src/format/rle.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, ensure, Result};
 use std::fmt;
 use std::io::{BufRead, BufReader, Read};
 
-/// A representation for RLE file format, described in <https://conwaylife.com/wiki/Run_Length_Encoded>.
+/// A representation for RLE file format, described in <https://conwaylife.com/wiki/Run_Length_Encoded> and <https://golly.sourceforge.net/Help/formats.html#rle>.
 #[derive(Debug, Clone)]
 pub struct Rle {
     comments: Vec<String>,

--- a/src/format/rle.rs
+++ b/src/format/rle.rs
@@ -278,16 +278,14 @@ where
                     None => Vec::new(),
                 }
             };
-            let mut buf = Vec::new();
-            {
-                let name = self.name.drain();
-                if let Some(str) = &name {
-                    ensure!(str.lines().count() <= 1, "the string passed by name(str) includes multiple lines");
-                }
-                buf.append(&mut parse_to_comments(name, "#N"));
+            let name = self.name.drain();
+            if let Some(str) = &name {
+                ensure!(str.lines().count() <= 1, "the string passed by name(str) includes multiple lines");
             }
-            buf.append(&mut parse_to_comments(self.created.drain(), "#O"));
-            buf.append(&mut parse_to_comments(self.comment.drain(), "#C"));
+            let mut buf = Vec::new();
+            for (str, prefix) in [(name, "#N"), (self.created.drain(), "#O"), (self.comment.drain(), "#C")] {
+                buf.extend(parse_to_comments(str, prefix).into_iter());
+            }
             buf
         };
         let contents_group_by_y = self.contents.into_iter().fold(HashMap::new(), |mut acc, (x, y)| {

--- a/src/format/rle.rs
+++ b/src/format/rle.rs
@@ -293,7 +293,7 @@ where
         });
         let contents_sorted = {
             let mut contents_sorted: Vec<_> = contents_group_by_y.into_iter().collect();
-            contents_sorted.sort_by(|(y0, _), (y1, _)| y0.partial_cmp(y1).unwrap()); // note: this unwrap never panic because <usize>.partial_cmp(<usize>) always returns Some(_)
+            contents_sorted.sort_by(|(y0, _), (y1, _)| y0.partial_cmp(y1).unwrap()); // this unwrap never panic because <usize>.partial_cmp(<usize>) always returns Some(_)
             for (_, xs) in &mut contents_sorted {
                 xs.sort();
             }

--- a/src/format/rle.rs
+++ b/src/format/rle.rs
@@ -1053,7 +1053,7 @@ mod tests {
         Ok(())
     }
     #[test]
-    fn test_blank_created() -> Result<()> {
+    fn test_build_blank_created() -> Result<()> {
         let pattern = [(0, 0)];
         let target = pattern.iter().collect::<RleBuilder>().created("").build()?;
         let expected_comments = vec!["#O"];
@@ -1080,7 +1080,7 @@ mod tests {
         Ok(())
     }
     #[test]
-    fn test_blank_comment() -> Result<()> {
+    fn test_build_blank_comment() -> Result<()> {
         let pattern = [(0, 0)];
         let target = pattern.iter().collect::<RleBuilder>().comment("").build()?;
         let expected_comments = vec!["#C"];

--- a/src/format/rle.rs
+++ b/src/format/rle.rs
@@ -237,7 +237,7 @@ where
     /// ```
     /// # use life_backend::format::RleBuilder;
     /// let pattern = [(1, 0), (0, 1)];
-    /// let rle = pattern.iter().collect::<RleBuilder>().build().unwrap();
+    /// let target = pattern.iter().collect::<RleBuilder>().build().unwrap();
     /// ```
     ///
     pub fn build(self) -> Result<Rle> {
@@ -331,9 +331,9 @@ where
     /// ```
     /// # use life_backend::format::RleBuilder;
     /// let pattern = [(1, 0), (0, 1)];
-    /// let rle = pattern.iter().collect::<RleBuilder>().name("foo").build().unwrap();
-    /// assert_eq!(rle.comments().len(), 1);
-    /// assert_eq!(rle.comments()[0], "#N foo".to_string());
+    /// let target = pattern.iter().collect::<RleBuilder>().name("foo").build().unwrap();
+    /// assert_eq!(target.comments().len(), 1);
+    /// assert_eq!(target.comments()[0], "#N foo".to_string());
     /// ```
     ///
     /// # Errors
@@ -343,7 +343,7 @@ where
     /// ```compile_fail
     /// # use life_backend::format::RleBuilder;
     /// let pattern = [(1, 0), (0, 1)];
-    /// let rle = pattern.iter().collect::<RleBuilder>().name("foo").name("bar").build().unwrap(); // Compile error
+    /// let target = pattern.iter().collect::<RleBuilder>().name("foo").name("bar").build().unwrap(); // Compile error
     /// ```
     ///
     /// build() returns an error if the string passed by name(str) includes multiple lines.  For example:
@@ -351,7 +351,7 @@ where
     /// ```should_panic
     /// # use life_backend::format::RleBuilder;
     /// let pattern = [(1, 0), (0, 1)];
-    /// let rle = pattern.iter().collect::<RleBuilder>().name("foo\nbar").build().unwrap();
+    /// let target = pattern.iter().collect::<RleBuilder>().name("foo\nbar").build().unwrap();
     /// ```
     ///
     pub fn name(self, str: &str) -> RleBuilder<RleBuilderWithName, Created, Comment> {
@@ -377,9 +377,9 @@ where
     /// ```
     /// # use life_backend::format::RleBuilder;
     /// let pattern = [(1, 0), (0, 1)];
-    /// let rle = pattern.iter().collect::<RleBuilder>().created("foo").build().unwrap();
-    /// assert_eq!(rle.comments().len(), 1);
-    /// assert_eq!(rle.comments()[0], "#O foo".to_string());
+    /// let target = pattern.iter().collect::<RleBuilder>().created("foo").build().unwrap();
+    /// assert_eq!(target.comments().len(), 1);
+    /// assert_eq!(target.comments()[0], "#O foo".to_string());
     /// ```
     ///
     /// # Errors
@@ -389,7 +389,7 @@ where
     /// ```compile_fail
     /// # use life_backend::format::RleBuilder;
     /// let pattern = [(1, 0), (0, 1)];
-    /// let rle = pattern.iter().collect::<RleBuilder>().created("foo").created("bar").build().unwrap(); // Compile error
+    /// let target = pattern.iter().collect::<RleBuilder>().created("foo").created("bar").build().unwrap(); // Compile error
     /// ```
     ///
     pub fn created(self, str: &str) -> RleBuilder<Name, RleBuilderWithCreated, Comment> {
@@ -415,10 +415,10 @@ where
     /// ```
     /// # use life_backend::format::RleBuilder;
     /// let pattern = [(1, 0), (0, 1)];
-    /// let rle = pattern.iter().collect::<RleBuilder>().comment("comment0\ncomment1").build().unwrap();
-    /// assert_eq!(rle.comments().len(), 2);
-    /// assert_eq!(rle.comments()[0], "#C comment0".to_string());
-    /// assert_eq!(rle.comments()[1], "#C comment1".to_string());
+    /// let target = pattern.iter().collect::<RleBuilder>().comment("comment0\ncomment1").build().unwrap();
+    /// assert_eq!(target.comments().len(), 2);
+    /// assert_eq!(target.comments()[0], "#C comment0".to_string());
+    /// assert_eq!(target.comments()[1], "#C comment1".to_string());
     /// ```
     ///
     /// # Errors
@@ -428,7 +428,7 @@ where
     /// ```compile_fail
     /// # use life_backend::format::RleBuilder;
     /// let pattern = [(1, 0), (0, 1)];
-    /// let rle = pattern.iter().collect::<RleBuilder>().comment("comment0").comment("comment1").build().unwrap(); // Compile error
+    /// let target = pattern.iter().collect::<RleBuilder>().comment("comment0").comment("comment1").build().unwrap(); // Compile error
     /// ```
     ///
     pub fn comment(self, str: &str) -> RleBuilder<Name, Created, RleBuilderWithComment> {
@@ -454,7 +454,7 @@ impl<'a> FromIterator<&'a (usize, usize)> for RleBuilder<RleBuilderNoName, RleBu
     /// # use life_backend::format::RleBuilder;
     /// let pattern = [(1, 0), (0, 1)];
     /// let builder = pattern.iter().collect::<RleBuilder>();
-    /// let rle = builder.build().unwrap();
+    /// let target = builder.build().unwrap();
     /// ```
     ///
     fn from_iter<T>(iter: T) -> Self
@@ -481,7 +481,7 @@ impl FromIterator<(usize, usize)> for RleBuilder<RleBuilderNoName, RleBuilderNoC
     /// # use life_backend::format::RleBuilder;
     /// let pattern = [(1, 0), (0, 1)];
     /// let builder = pattern.into_iter().collect::<RleBuilder>();
-    /// let rle = builder.build().unwrap();
+    /// let target = builder.build().unwrap();
     /// ```
     ///
     fn from_iter<T>(iter: T) -> Self

--- a/src/format/rle.rs
+++ b/src/format/rle.rs
@@ -282,7 +282,7 @@ where
             {
                 let name = self.name.drain();
                 if let Some(str) = &name {
-                    ensure!(str.lines().count() <= 1, "the string passed by name() includes multiple lines");
+                    ensure!(str.lines().count() <= 1, "the string passed by name(str) includes multiple lines");
                 }
                 buf.append(&mut parse_to_comments(name, "#N"));
             }

--- a/src/format/rle.rs
+++ b/src/format/rle.rs
@@ -58,7 +58,7 @@ where
     contents: HashSet<(usize, usize)>,
 }
 
-// Traits and Types for RleBuilder's typestate
+// Traits and types for RleBuilder's typestate
 pub trait RleBuilderName {
     fn drain(self) -> Option<String>;
 }
@@ -391,7 +391,7 @@ where
     Name: RleBuilderName,
     Comment: RleBuilderComment,
 {
-    /// Set the information when and whom the pattern was created. If the argument includes newlines, the instance of Rle built by build() includes multiple comment lines.
+    /// Set the information when and by whom the pattern was created. If the argument includes newlines, the instance of Rle built by build() includes multiple comment lines.
     ///
     /// # Examples
     ///

--- a/src/format/rle.rs
+++ b/src/format/rle.rs
@@ -1020,6 +1020,99 @@ mod tests {
         Ok(())
     }
     #[test]
+    fn test_build_singleline_name() -> Result<()> {
+        let pattern = [(0, 0)];
+        let target = pattern.iter().collect::<RleBuilder>().name("name").build()?;
+        let expected_comments = vec!["#N name"];
+        let expected_contents = vec![(0, 0, 1)];
+        do_check(&target, &expected_comments, &expected_contents, None);
+        Ok(())
+    }
+    #[test]
+    fn test_build_blank_name() -> Result<()> {
+        let pattern = [(0, 0)];
+        let target = pattern.iter().collect::<RleBuilder>().name("").build()?;
+        let expected_comments = vec!["#N"];
+        let expected_contents = vec![(0, 0, 1)];
+        do_check(&target, &expected_comments, &expected_contents, None);
+        Ok(())
+    }
+    #[test]
+    fn test_build_multiline_name() {
+        let pattern = [(0, 0)];
+        let target = pattern.iter().collect::<RleBuilder>().name("name\nname").build();
+        assert!(target.is_err());
+    }
+    #[test]
+    fn test_build_created() -> Result<()> {
+        let pattern = [(0, 0)];
+        let target = pattern.iter().collect::<RleBuilder>().created("created").build()?;
+        let expected_comments = vec!["#O created"];
+        let expected_contents = vec![(0, 0, 1)];
+        do_check(&target, &expected_comments, &expected_contents, None);
+        Ok(())
+    }
+    #[test]
+    fn test_blank_created() -> Result<()> {
+        let pattern = [(0, 0)];
+        let target = pattern.iter().collect::<RleBuilder>().created("").build()?;
+        let expected_comments = vec!["#O"];
+        let expected_contents = vec![(0, 0, 1)];
+        do_check(&target, &expected_comments, &expected_contents, None);
+        Ok(())
+    }
+    #[test]
+    fn test_build_createds() -> Result<()> {
+        let pattern = [(0, 0)];
+        let target = pattern.iter().collect::<RleBuilder>().created("created0\ncreated1").build()?;
+        let expected_comments = vec!["#O created0", "#O created1"];
+        let expected_contents = vec![(0, 0, 1)];
+        do_check(&target, &expected_comments, &expected_contents, None);
+        Ok(())
+    }
+    #[test]
+    fn test_build_comment() -> Result<()> {
+        let pattern = [(0, 0)];
+        let target = pattern.iter().collect::<RleBuilder>().comment("comment").build()?;
+        let expected_comments = vec!["#C comment"];
+        let expected_contents = vec![(0, 0, 1)];
+        do_check(&target, &expected_comments, &expected_contents, None);
+        Ok(())
+    }
+    #[test]
+    fn test_blank_comment() -> Result<()> {
+        let pattern = [(0, 0)];
+        let target = pattern.iter().collect::<RleBuilder>().comment("").build()?;
+        let expected_comments = vec!["#C"];
+        let expected_contents = vec![(0, 0, 1)];
+        do_check(&target, &expected_comments, &expected_contents, None);
+        Ok(())
+    }
+    #[test]
+    fn test_build_comments() -> Result<()> {
+        let pattern = [(0, 0)];
+        let target = pattern.iter().collect::<RleBuilder>().comment("comment0\ncomment1").build()?;
+        let expected_comments = vec!["#C comment0", "#C comment1"];
+        let expected_contents = vec![(0, 0, 1)];
+        do_check(&target, &expected_comments, &expected_contents, None);
+        Ok(())
+    }
+    #[test]
+    fn test_build_name_created_comment() -> Result<()> {
+        let pattern = [(0, 0)];
+        let target = pattern
+            .iter()
+            .collect::<RleBuilder>()
+            .name("name")
+            .created("created")
+            .comment("comment")
+            .build()?;
+        let expected_comments = vec!["#N name", "#O created", "#C comment"];
+        let expected_contents = vec![(0, 0, 1)];
+        do_check(&target, &expected_comments, &expected_contents, None);
+        Ok(())
+    }
+    #[test]
     fn test_display_max_width() -> Result<()> {
         let pattern = ["x = 72, y = 1", &"bo".repeat(35), "bo!"]
             .iter()

--- a/src/format/rle.rs
+++ b/src/format/rle.rs
@@ -522,42 +522,47 @@ impl FromIterator<(usize, usize)> for RleBuilder<RleBuilderNoName, RleBuilderNoC
 impl Rle {
     // Convert the series of (usize, RleTag) into the series of RleLiveCellRun.
     fn convert_tags_to_livecellruns(tags: &[(usize, RleTag)]) -> Vec<RleLiveCellRun> {
-        let mut buf = Vec::new();
-        let mut item = RleLiveCellRun {
-            pad_lines: 0,
-            pad_dead_cells: 0,
-            live_cells: 0,
-        };
-        for tag in tags {
-            match *tag {
-                (n, RleTag::AliveCell) => item.live_cells += n,
-                (n, RleTag::DeadCell) => {
-                    if item.live_cells > 0 {
-                        buf.push(item);
-                        item = RleLiveCellRun {
-                            pad_lines: 0,
-                            pad_dead_cells: n,
-                            live_cells: 0,
-                        };
-                    } else {
-                        item.pad_dead_cells += n;
+        let (mut buf, item) = tags.iter().fold(
+            (
+                Vec::new(),
+                RleLiveCellRun {
+                    pad_lines: 0,
+                    pad_dead_cells: 0,
+                    live_cells: 0,
+                },
+            ),
+            |(mut buf, mut item), tag| {
+                match *tag {
+                    (n, RleTag::AliveCell) => item.live_cells += n,
+                    (n, RleTag::DeadCell) => {
+                        if item.live_cells > 0 {
+                            buf.push(item);
+                            item = RleLiveCellRun {
+                                pad_lines: 0,
+                                pad_dead_cells: n,
+                                live_cells: 0,
+                            };
+                        } else {
+                            item.pad_dead_cells += n;
+                        }
+                    }
+                    (n, RleTag::EndOfLine) => {
+                        if item.live_cells > 0 {
+                            buf.push(item);
+                            item = RleLiveCellRun {
+                                pad_lines: n,
+                                pad_dead_cells: 0,
+                                live_cells: 0,
+                            };
+                        } else {
+                            item.pad_lines += n;
+                            item.pad_dead_cells = 0;
+                        }
                     }
                 }
-                (n, RleTag::EndOfLine) => {
-                    if item.live_cells > 0 {
-                        buf.push(item);
-                        item = RleLiveCellRun {
-                            pad_lines: n,
-                            pad_dead_cells: 0,
-                            live_cells: 0,
-                        };
-                    } else {
-                        item.pad_lines += n;
-                        item.pad_dead_cells = 0;
-                    }
-                }
-            }
-        }
+                (buf, item)
+            },
+        );
         if item.live_cells > 0 {
             buf.push(item);
         }

--- a/src/format/rle.rs
+++ b/src/format/rle.rs
@@ -712,12 +712,13 @@ impl fmt::Display for Rle {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         const MAX_LINE_WIDTH: usize = 70;
         let count_tag_to_string = |count: usize, char| {
-            let mut buf = String::new();
             if count > 1 {
-                buf.push_str(&format!("{}", count));
-            }
+                let mut buf = count.to_string();
             buf.push(char);
             buf
+            } else {
+                char.to_string()
+            }
         };
         let flush_buf = |f: &mut fmt::Formatter, buf: &mut String| {
             writeln!(f, "{buf}")?;

--- a/src/format/rle.rs
+++ b/src/format/rle.rs
@@ -723,12 +723,12 @@ impl fmt::Display for Rle {
             writeln!(f, "{buf}")?;
             Ok(())
         };
-        let write_with_buf = |f: &mut fmt::Formatter, buf: &mut String, s: String| {
+        let write_with_buf = |f: &mut fmt::Formatter, buf: &mut String, s: &str| {
             if buf.len() + s.len() > MAX_LINE_WIDTH {
                 flush_buf(f, buf)?;
                 buf.clear();
             }
-            buf.push_str(&s);
+            buf.push_str(s);
             Ok(())
         };
         for line in self.comments() {
@@ -740,11 +740,11 @@ impl fmt::Display for Rle {
             for (count, char) in [(x.pad_lines, '$'), (x.pad_dead_cells, 'b'), (x.live_cells, 'o')] {
                 if count > 0 {
                     let s = count_tag_to_string(count, char);
-                    write_with_buf(f, &mut buf, s)?;
+                    write_with_buf(f, &mut buf, &s)?;
                 }
             }
         }
-        write_with_buf(f, &mut buf, String::from("!"))?;
+        write_with_buf(f, &mut buf, "!")?;
         flush_buf(f, &mut buf)?;
         Ok(())
     }

--- a/src/format/rle.rs
+++ b/src/format/rle.rs
@@ -356,7 +356,7 @@ where
     ///
     pub fn name(self, str: &str) -> RleBuilder<RleBuilderWithName, Created, Comment> {
         let name = RleBuilderWithName(str.to_string());
-        RleBuilder::<RleBuilderWithName, Created, Comment> {
+        RleBuilder {
             name,
             created: self.created,
             comment: self.comment,
@@ -394,7 +394,7 @@ where
     ///
     pub fn created(self, str: &str) -> RleBuilder<Name, RleBuilderWithCreated, Comment> {
         let created = RleBuilderWithCreated(str.to_string());
-        RleBuilder::<Name, RleBuilderWithCreated, Comment> {
+        RleBuilder {
             name: self.name,
             created,
             comment: self.comment,
@@ -433,7 +433,7 @@ where
     ///
     pub fn comment(self, str: &str) -> RleBuilder<Name, Created, RleBuilderWithComment> {
         let comment = RleBuilderWithComment(str.to_string());
-        RleBuilder::<Name, Created, RleBuilderWithComment> {
+        RleBuilder {
             name: self.name,
             created: self.created,
             comment,

--- a/src/format/rle.rs
+++ b/src/format/rle.rs
@@ -259,8 +259,8 @@ where
     pub fn build(self) -> Result<Rle> {
         let comments = {
             let parse_to_comments = |str: Option<String>, prefix: &str| {
-                let prefixed_str = |str: &str, prefix| {
-                    let mut buf = String::from(prefix);
+                let prefixed_str = |str: &str, prefix: &str| {
+                    let mut buf = prefix.to_string();
                     if !str.is_empty() {
                         buf.push(' ');
                         buf.push_str(str);
@@ -270,7 +270,7 @@ where
                 match str {
                     Some(str) => {
                         if str.is_empty() {
-                            vec![String::from(prefix)]
+                            vec![prefix.to_string()]
                         } else {
                             str.lines().map(|s| prefixed_str(s, prefix)).collect::<Vec<_>>()
                         }
@@ -351,7 +351,7 @@ where
     /// let pattern = [(1, 0), (0, 1)];
     /// let rle = pattern.iter().collect::<RleBuilder>().name("foo").build().unwrap();
     /// assert_eq!(rle.comments().len(), 1);
-    /// assert_eq!(rle.comments()[0], String::from("#N foo"));
+    /// assert_eq!(rle.comments()[0], "#N foo".to_string());
     /// ```
     ///
     /// # Errors
@@ -397,7 +397,7 @@ where
     /// let pattern = [(1, 0), (0, 1)];
     /// let rle = pattern.iter().collect::<RleBuilder>().created("foo").build().unwrap();
     /// assert_eq!(rle.comments().len(), 1);
-    /// assert_eq!(rle.comments()[0], String::from("#O foo"));
+    /// assert_eq!(rle.comments()[0], "#O foo".to_string());
     /// ```
     ///
     /// # Errors
@@ -435,8 +435,8 @@ where
     /// let pattern = [(1, 0), (0, 1)];
     /// let rle = pattern.iter().collect::<RleBuilder>().comment("comment0\ncomment1").build().unwrap();
     /// assert_eq!(rle.comments().len(), 2);
-    /// assert_eq!(rle.comments()[0], String::from("#C comment0"));
-    /// assert_eq!(rle.comments()[1], String::from("#C comment1"));
+    /// assert_eq!(rle.comments()[0], "#C comment0".to_string());
+    /// assert_eq!(rle.comments()[1], "#C comment1".to_string());
     /// ```
     ///
     /// # Errors
@@ -1119,7 +1119,7 @@ mod tests {
     fn test_display_max_width() -> Result<()> {
         let pattern = ["x = 72, y = 1", &"bo".repeat(35), "bo!"]
             .iter()
-            .map(|&s| String::from(s) + "\n")
+            .map(|&s| s.to_string() + "\n")
             .collect::<String>();
         let target = Rle::new(pattern.as_bytes())?;
         assert_eq!(target.to_string(), pattern);

--- a/src/format/rle.rs
+++ b/src/format/rle.rs
@@ -159,7 +159,7 @@ impl RleParser {
                 Some(c) if c.is_ascii_digit() => {
                     let (num_str, rest) = line.split_at(line.find(|c: char| !c.is_ascii_digit()).unwrap_or(line.len()));
                     ensure!(!rest.is_empty(), "The pattern is in wrong format");
-                    let num: usize = num_str.parse().unwrap_or_default();
+                    let num: usize = num_str.parse().unwrap(); // this unwrap never panic because num_str only includes ascii digits
                     line = rest;
                     Some(num)
                 }

--- a/tests/format_plaintext.rs
+++ b/tests/format_plaintext.rs
@@ -33,15 +33,15 @@ fn do_new_test_with_path(input_path_string: &str, expected_positions: &[(usize, 
     do_new_test(file, expected_positions)
 }
 
-fn do_build_test(pattern: &[(usize, usize)], name: Option<String>, comment: Option<String>) {
+fn do_build_test(pattern: &[(usize, usize)], name: Option<String>, comment: Option<String>) -> Result<()> {
     // Create the target with the pattern, the name and the comment
     let target = {
         let builder = pattern.iter().collect::<PlaintextBuilder>();
         match (&name, &comment) {
-            (None, None) => builder.build(),
-            (Some(name), None) => builder.name(name).build(),
-            (None, Some(comment)) => builder.comment(comment).build(),
-            (Some(name), Some(comment)) => builder.name(name).comment(comment).build(),
+            (None, None) => builder.build()?,
+            (Some(name), None) => builder.name(name).build()?,
+            (None, Some(comment)) => builder.comment(comment).build()?,
+            (Some(name), Some(comment)) => builder.name(name).comment(comment).build()?,
         }
     };
     println!("Target:");
@@ -58,6 +58,7 @@ fn do_build_test(pattern: &[(usize, usize)], name: Option<String>, comment: Opti
         let comments: Vec<_> = comment.lines().map(|s| s.to_string()).collect();
         assert_eq!(target.comments(), &comments);
     }
+    Ok(())
 }
 
 #[test]
@@ -80,9 +81,9 @@ fn format_plaintext_new_with_file_test() -> Result<()> {
 }
 
 #[test]
-fn format_plaintext_build_test() {
+fn format_plaintext_build_test() -> Result<()> {
     let pattern = vec![(1, 0), (2, 1), (0, 2), (1, 2), (2, 2)];
     let name = Some(String::from("Glider"));
     let comment = Some(String::from("----"));
-    do_build_test(&pattern, name, comment);
+    do_build_test(&pattern, name, comment)
 }

--- a/tests/format_plaintext.rs
+++ b/tests/format_plaintext.rs
@@ -83,7 +83,7 @@ fn format_plaintext_new_with_file_test() -> Result<()> {
 #[test]
 fn format_plaintext_build_test() -> Result<()> {
     let pattern = vec![(1, 0), (2, 1), (0, 2), (1, 2), (2, 2)];
-    let name = Some(String::from("Glider"));
-    let comment = Some(String::from("----"));
+    let name = Some("Glider".to_string());
+    let comment = Some("----".to_string());
     do_build_test(&pattern, name, comment)
 }

--- a/tests/format_plaintext.rs
+++ b/tests/format_plaintext.rs
@@ -1,11 +1,11 @@
 use anyhow::{Context, Result};
-use life_backend::format::Plaintext;
+use life_backend::format::{Plaintext, PlaintextBuilder};
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
 
 // Execute the test with the Read implementor and the expected positions.
-fn do_test<R>(read: R, expected_positions: &[(usize, usize)]) -> Result<()>
+fn do_new_test<R>(read: R, expected_positions: &[(usize, usize)]) -> Result<()>
 where
     R: Read,
 {
@@ -18,18 +18,47 @@ where
     println!("Expected positions:");
     println!("{:?}", expected_positions);
 
+    // Check
     assert!(target.iter().eq(expected_positions.iter().copied()));
     Ok(())
 }
 
-fn do_test_with_string(input_string: &str, expected_positions: &[(usize, usize)]) -> Result<()> {
-    do_test(input_string.as_bytes(), expected_positions)
+fn do_new_test_with_string(input_string: &str, expected_positions: &[(usize, usize)]) -> Result<()> {
+    do_new_test(input_string.as_bytes(), expected_positions)
 }
 
-fn do_test_with_path(input_path_string: &str, expected_positions: &[(usize, usize)]) -> Result<()> {
+fn do_new_test_with_path(input_path_string: &str, expected_positions: &[(usize, usize)]) -> Result<()> {
     let path = Path::new(input_path_string);
     let file = File::open(path).with_context(|| format!("Failed to open \"{}\"", path.display()))?;
-    do_test(file, expected_positions)
+    do_new_test(file, expected_positions)
+}
+
+fn do_build_test(pattern: &[(usize, usize)], name: Option<String>, comment: Option<String>) {
+    // Create the target with the pattern, the name and the comment
+    let target = {
+        let mut builder = pattern.iter().collect::<PlaintextBuilder>();
+        if let Some(name) = &name {
+            builder = builder.name(name);
+        }
+        if let Some(comment) = &comment {
+            builder = builder.comment(comment);
+        }
+        builder.build()
+    };
+    println!("Target:");
+    println!("{target}");
+
+    // Show the pattern
+    println!("Pattern:");
+    println!("{:?}", pattern);
+
+    // Check
+    assert!(target.iter().eq(pattern.iter().copied()));
+    assert_eq!(target.name(), name);
+    if let Some(comment) = &comment {
+        let comments: Vec<_> = comment.lines().map(|s| s.to_string()).collect();
+        assert_eq!(target.comments(), &comments);
+    }
 }
 
 #[test]
@@ -41,12 +70,20 @@ fn format_plaintext_new_with_string_test() -> Result<()> {
         OOO\n\
     ";
     let expected_positions = vec![(1, 0), (2, 1), (0, 2), (1, 2), (2, 2)];
-    do_test_with_string(input_pattern, &expected_positions)
+    do_new_test_with_string(input_pattern, &expected_positions)
 }
 
 #[test]
 fn format_plaintext_new_with_file_test() -> Result<()> {
     let input_path_string = concat!(env!("CARGO_MANIFEST_DIR"), "/patterns/rpentomino.cells");
     let expected_positions = vec![(1, 0), (2, 0), (0, 1), (1, 1), (1, 2)];
-    do_test_with_path(input_path_string, &expected_positions)
+    do_new_test_with_path(input_path_string, &expected_positions)
+}
+
+#[test]
+fn format_plaintext_build_test() {
+    let pattern = vec![(1, 0), (2, 1), (0, 2), (1, 2), (2, 2)];
+    let name = Some(String::from("Glider"));
+    let comment = Some(String::from("----"));
+    do_build_test(&pattern, name, comment);
 }

--- a/tests/format_plaintext.rs
+++ b/tests/format_plaintext.rs
@@ -36,14 +36,13 @@ fn do_new_test_with_path(input_path_string: &str, expected_positions: &[(usize, 
 fn do_build_test(pattern: &[(usize, usize)], name: Option<String>, comment: Option<String>) {
     // Create the target with the pattern, the name and the comment
     let target = {
-        let mut builder = pattern.iter().collect::<PlaintextBuilder>();
-        if let Some(name) = &name {
-            builder = builder.name(name);
+        let builder = pattern.iter().collect::<PlaintextBuilder>();
+        match (&name, &comment) {
+            (None, None) => builder.build(),
+            (Some(name), None) => builder.name(name).build(),
+            (None, Some(comment)) => builder.comment(comment).build(),
+            (Some(name), Some(comment)) => builder.name(name).comment(comment).build(),
         }
-        if let Some(comment) = &comment {
-            builder = builder.comment(comment);
-        }
-        builder.build()
     };
     println!("Target:");
     println!("{target}");

--- a/tests/format_rle.rs
+++ b/tests/format_rle.rs
@@ -81,5 +81,6 @@ fn format_rle_new_with_file_test() -> Result<()> {
 fn format_rle_build_test() -> Result<()> {
     let pattern = vec![(0, 0), (1, 0), (2, 0), (1, 1)];
     let name = Some(String::from("T-tetromino"));
-    do_build_test(&pattern, name, None, None)
+    let comment = Some(String::from("----"));
+    do_build_test(&pattern, name, None, comment)
 }

--- a/tests/format_rle.rs
+++ b/tests/format_rle.rs
@@ -80,7 +80,7 @@ fn format_rle_new_with_file_test() -> Result<()> {
 #[test]
 fn format_rle_build_test() -> Result<()> {
     let pattern = vec![(0, 0), (1, 0), (2, 0), (1, 1)];
-    let name = Some(String::from("T-tetromino"));
-    let comment = Some(String::from("----"));
+    let name = Some("T-tetromino".to_string());
+    let comment = Some("----".to_string());
     do_build_test(&pattern, name, None, comment)
 }


### PR DESCRIPTION
format::PlaintextBuilder and format::RleBuilder are added.
Below code is supported:

```rust
fn main() {
    let pattern = [(1, 0), (0, 1)];
    let plaintext = pattern.iter().collect::<PlaintextBuilder>().name("foo").build().unwrap();
    println!("{plaintext}");
}
```

```shell
$ cargo run
!Name: foo
.O
O.
```