### PR TITLE
Improvements of minor features, documentation, tests and implementation

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -37,7 +37,7 @@ where
 
 macro_rules! create_benchmark_function {
     ($function_name:ident, $id:literal, $relative_path_string:literal, $steps:expr) => {
-        fn $function_name(c: &mut Criterion) {
+        pub fn $function_name(c: &mut Criterion) {
             let id = $id;
             let path = $relative_path_string;
             let steps = $steps;
@@ -46,33 +46,22 @@ macro_rules! create_benchmark_function {
     };
 }
 
-create_benchmark_function!(oscillator_blinker_benchmark, "oscillator-blinker", "patterns/blinker.rle", 2);
-create_benchmark_function!(
-    oscillator_pentadecathlon_benchmark,
-    "oscillator-pentadecathlon",
-    "patterns/pentadecathlon.rle",
-    15
-);
-create_benchmark_function!(
-    oscillator_queenbeeshuttle_benchmark,
-    "oscillator-queenbeeshuttle",
-    "patterns/transqueenbeeshuttle.rle",
-    30
-);
-create_benchmark_function!(
-    oscillator_p60glidershuttle_benchmark,
-    "oscillator-p60glidershuttle",
-    "patterns/p60glidershuttle.rle",
-    60
-);
-create_benchmark_function!(oscillator_centinal_benchmark, "oscillator-centinal", "patterns/centinal.rle", 100);
+#[rustfmt::skip]
+mod benchmarks {
+    use super::*;
+    create_benchmark_function!(oscillator_blinker_benchmark, "oscillator-blinker", "patterns/blinker.rle", 2);
+    create_benchmark_function!(oscillator_pentadecathlon_benchmark, "oscillator-pentadecathlon", "patterns/pentadecathlon.rle", 15);
+    create_benchmark_function!(oscillator_queenbeeshuttle_benchmark, "oscillator-queenbeeshuttle", "patterns/transqueenbeeshuttle.rle", 30);
+    create_benchmark_function!(oscillator_p60glidershuttle_benchmark, "oscillator-p60glidershuttle", "patterns/p60glidershuttle.rle", 60);
+    create_benchmark_function!(oscillator_centinal_benchmark, "oscillator-centinal", "patterns/centinal.rle", 100);
+}
 
 criterion_group!(
     benches,
-    oscillator_blinker_benchmark,
-    oscillator_pentadecathlon_benchmark,
-    oscillator_queenbeeshuttle_benchmark,
-    oscillator_p60glidershuttle_benchmark,
-    oscillator_centinal_benchmark
+    benchmarks::oscillator_blinker_benchmark,
+    benchmarks::oscillator_pentadecathlon_benchmark,
+    benchmarks::oscillator_queenbeeshuttle_benchmark,
+    benchmarks::oscillator_p60glidershuttle_benchmark,
+    benchmarks::oscillator_centinal_benchmark
 );
 criterion_main!(benches);

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -50,7 +50,6 @@ create_benchmark_function!(blinker_1k_benchmark, "blinker-1k", "patterns/blinker
 create_benchmark_function!(pentadecathlon_1k_benchmark, "pentadecathlon-1k", "patterns/pentadecathlon.rle", 1000);
 create_benchmark_function!(queenbeeshuttle_1k_benchmark, "queenbeeshuttle-1k", "patterns/transqueenbeeshuttle.rle", 1000);
 create_benchmark_function!(p60glidershuttle_1k_benchmark, "p60glidershuttle-1k", "patterns/p60glidershuttle.rle", 1000);
-create_benchmark_function!(moldon30p25_1k_benchmark, "moldon30p25-1k", "patterns/moldon30p25.rle", 1000);
 create_benchmark_function!(centinal_1k_benchmark, "centinal-1k", "patterns/centinal.rle", 1000);
 
 criterion_group!(
@@ -59,7 +58,6 @@ criterion_group!(
     pentadecathlon_1k_benchmark,
     queenbeeshuttle_1k_benchmark,
     p60glidershuttle_1k_benchmark,
-    moldon30p25_1k_benchmark,
     centinal_1k_benchmark
 );
 criterion_main!(benches);

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -40,7 +40,7 @@ macro_rules! create_benchmark_function {
     ($function_name:ident, $id:literal, $relative_path_string:literal, $steps:expr) => {
         fn $function_name(c: &mut Criterion) {
             let id = $id;
-            let path = concat!(env!("CARGO_MANIFEST_DIR"), "/", $relative_path_string);
+            let path = $relative_path_string;
             let steps = $steps;
             do_benchmark::<i8, _>(c, id, path, steps).unwrap();
         }

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -3,6 +3,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use num_traits::{Bounded, FromPrimitive, One, ToPrimitive, Zero};
 use std::hash::Hash;
 use std::ops::{Add, Sub};
+use std::path::Path;
 
 use life_backend::format;
 use life_backend::{Board, Game, Position};
@@ -17,13 +18,14 @@ where
     }
 }
 
-fn do_benchmark<CoordinateType>(c: &mut Criterion, id: &str, path_str: &str, steps: usize) -> Result<()>
+fn do_benchmark<CoordinateType, P>(c: &mut Criterion, id: &str, path: P, steps: usize) -> Result<()>
 where
     CoordinateType:
         Eq + Hash + Copy + PartialOrd + Add<Output = CoordinateType> + Sub<Output = CoordinateType> + Zero + One + Bounded + ToPrimitive + FromPrimitive,
+    P: AsRef<Path>,
 {
     let from_usize_unwrap = |x| CoordinateType::from_usize(x).unwrap();
-    let handler = format::open(path_str)?;
+    let handler = format::open(path)?;
     let rule = handler.rule();
     let board: Board<_> = handler
         .live_cells()
@@ -38,9 +40,9 @@ macro_rules! create_benchmark_function {
     ($function_name:ident, $id:literal, $relative_path_string:literal, $steps:expr) => {
         fn $function_name(c: &mut Criterion) {
             let id = $id;
-            let path_str = concat!(env!("CARGO_MANIFEST_DIR"), "/", $relative_path_string);
+            let path = concat!(env!("CARGO_MANIFEST_DIR"), "/", $relative_path_string);
             let steps = $steps;
-            do_benchmark::<i8>(c, id, path_str, steps).unwrap();
+            do_benchmark::<i8, _>(c, id, path, steps).unwrap();
         }
     };
 }

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -8,9 +8,9 @@ use std::path::Path;
 use life_backend::format;
 use life_backend::{Board, Game, Position};
 
-fn workload<CoordinateType>(game: &Game<CoordinateType>, steps: usize)
+fn workload<T>(game: &Game<T>, steps: usize)
 where
-    CoordinateType: Eq + Hash + Copy + PartialOrd + Add<Output = CoordinateType> + Sub<Output = CoordinateType> + Zero + One + Bounded + ToPrimitive,
+    T: Eq + Hash + Copy + PartialOrd + Add<Output = T> + Sub<Output = T> + Zero + One + Bounded + ToPrimitive,
 {
     let mut game = game.clone();
     for _ in 0..steps {
@@ -18,13 +18,12 @@ where
     }
 }
 
-fn do_benchmark<CoordinateType, P>(c: &mut Criterion, id: &str, path: P, steps: usize) -> Result<()>
+fn do_benchmark<T, P>(c: &mut Criterion, id: &str, path: P, steps: usize) -> Result<()>
 where
-    CoordinateType:
-        Eq + Hash + Copy + PartialOrd + Add<Output = CoordinateType> + Sub<Output = CoordinateType> + Zero + One + Bounded + ToPrimitive + FromPrimitive,
+    T: Eq + Hash + Copy + PartialOrd + Add<Output = T> + Sub<Output = T> + Zero + One + Bounded + ToPrimitive + FromPrimitive,
     P: AsRef<Path>,
 {
-    let from_usize_unwrap = |x| CoordinateType::from_usize(x).unwrap();
+    let from_usize_unwrap = |x| T::from_usize(x).unwrap();
     let handler = format::open(path)?;
     let rule = handler.rule();
     let board: Board<_> = handler

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -46,18 +46,33 @@ macro_rules! create_benchmark_function {
     };
 }
 
-create_benchmark_function!(blinker_1k_benchmark, "blinker-1k", "patterns/blinker.rle", 1000);
-create_benchmark_function!(pentadecathlon_1k_benchmark, "pentadecathlon-1k", "patterns/pentadecathlon.rle", 1000);
-create_benchmark_function!(queenbeeshuttle_1k_benchmark, "queenbeeshuttle-1k", "patterns/transqueenbeeshuttle.rle", 1000);
-create_benchmark_function!(p60glidershuttle_1k_benchmark, "p60glidershuttle-1k", "patterns/p60glidershuttle.rle", 1000);
-create_benchmark_function!(centinal_1k_benchmark, "centinal-1k", "patterns/centinal.rle", 1000);
+create_benchmark_function!(oscillator_blinker_benchmark, "oscillator-blinker", "patterns/blinker.rle", 2);
+create_benchmark_function!(
+    oscillator_pentadecathlon_benchmark,
+    "oscillator-pentadecathlon",
+    "patterns/pentadecathlon.rle",
+    15
+);
+create_benchmark_function!(
+    oscillator_queenbeeshuttle_benchmark,
+    "oscillator-queenbeeshuttle",
+    "patterns/transqueenbeeshuttle.rle",
+    30
+);
+create_benchmark_function!(
+    oscillator_p60glidershuttle_benchmark,
+    "oscillator-p60glidershuttle",
+    "patterns/p60glidershuttle.rle",
+    60
+);
+create_benchmark_function!(oscillator_centinal_benchmark, "oscillator-centinal", "patterns/centinal.rle", 100);
 
 criterion_group!(
     benches,
-    blinker_1k_benchmark,
-    pentadecathlon_1k_benchmark,
-    queenbeeshuttle_1k_benchmark,
-    p60glidershuttle_1k_benchmark,
-    centinal_1k_benchmark
+    oscillator_blinker_benchmark,
+    oscillator_pentadecathlon_benchmark,
+    oscillator_queenbeeshuttle_benchmark,
+    oscillator_p60glidershuttle_benchmark,
+    oscillator_centinal_benchmark
 );
 criterion_main!(benches);

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -54,6 +54,8 @@ mod benchmarks {
     create_benchmark_function!(oscillator_queenbeeshuttle_benchmark, "oscillator-queenbeeshuttle", "patterns/transqueenbeeshuttle.rle", 30);
     create_benchmark_function!(oscillator_p60glidershuttle_benchmark, "oscillator-p60glidershuttle", "patterns/p60glidershuttle.rle", 60);
     create_benchmark_function!(oscillator_centinal_benchmark, "oscillator-centinal", "patterns/centinal.rle", 100);
+    create_benchmark_function!(methuselah_bheptomino_benchmark, "methuselah-bheptomino", "patterns/bheptomino.rle", 148);
+    create_benchmark_function!(methuselah_rpentomino_benchmark, "methuselah-rpentomino", "patterns/rpentomino.rle", 1103);
 }
 
 criterion_group!(
@@ -62,6 +64,8 @@ criterion_group!(
     benchmarks::oscillator_pentadecathlon_benchmark,
     benchmarks::oscillator_queenbeeshuttle_benchmark,
     benchmarks::oscillator_p60glidershuttle_benchmark,
-    benchmarks::oscillator_centinal_benchmark
+    benchmarks::oscillator_centinal_benchmark,
+    benchmarks::methuselah_bheptomino_benchmark,
+    benchmarks::methuselah_rpentomino_benchmark,
 );
 criterion_main!(benches);

--- a/patterns/moldon30p25.rle
+++ b/patterns/moldon30p25.rle
@@ -1,4 +1,0 @@
-#N moldon30p25
-x = 20, y = 20, rule = B3/S23
-18b2o$18bo$16bobo$10bo2bo2b2o$10bo2bo$9bo4bo$13bo$10b2obo5$6bob2o$6bo$
-5bo4bo$6bo2bo6b3o$2b2o2bo2bo4bob3o$bobo9bobobo$bo11bo2bo$2o12b2o!

--- a/src/board.rs
+++ b/src/board.rs
@@ -10,7 +10,7 @@ use crate::{BoardRange, Position};
 
 /// A representation of a two-dimensional orthogonal grid map of live/dead cells.
 ///
-/// The type parameter `CoordinateType` is used as the type of the x- and y-coordinate values for each cell.
+/// The type parameter `T` is used as the type of the x- and y-coordinate values for each cell.
 ///
 /// # Examples
 ///
@@ -28,15 +28,15 @@ use crate::{BoardRange, Position};
 /// ```
 ///
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Board<CoordinateType>(HashSet<Position<CoordinateType>, FnvBuildHasher>)
+pub struct Board<T>(HashSet<Position<T>, FnvBuildHasher>)
 where
-    CoordinateType: Eq + Hash;
+    T: Eq + Hash;
 
 // Inherent methods
 
-impl<CoordinateType> Board<CoordinateType>
+impl<T> Board<T>
 where
-    CoordinateType: Eq + Hash,
+    T: Eq + Hash,
 {
     /// Creates an empty board.
     ///
@@ -64,7 +64,7 @@ where
     /// ```
     ///
     #[inline]
-    pub fn get(&self, position: &Position<CoordinateType>) -> bool {
+    pub fn get(&self, position: &Position<T>) -> bool {
         self.0.contains(position)
     }
 
@@ -79,9 +79,9 @@ where
     /// assert_eq!(board.get(&Position(0, 0)), true);
     /// ```
     ///
-    pub fn set(&mut self, position: &Position<CoordinateType>, value: bool)
+    pub fn set(&mut self, position: &Position<T>, value: bool)
     where
-        CoordinateType: Copy,
+        T: Copy,
     {
         if value {
             self.0.insert(*position);
@@ -105,9 +105,9 @@ where
     /// ```
     ///
     #[inline]
-    pub fn bounding_box(&self) -> BoardRange<CoordinateType>
+    pub fn bounding_box(&self) -> BoardRange<T>
     where
-        CoordinateType: Copy + PartialOrd + Zero + One,
+        T: Copy + PartialOrd + Zero + One,
     {
         self.0.iter().collect::<BoardRange<_>>()
     }
@@ -148,15 +148,15 @@ where
     #[inline]
     pub fn retain<F>(&mut self, pred: F)
     where
-        F: FnMut(&Position<CoordinateType>) -> bool,
+        F: FnMut(&Position<T>) -> bool,
     {
         self.0.retain(pred);
     }
 }
 
-impl<'a, CoordinateType> Board<CoordinateType>
+impl<'a, T> Board<T>
 where
-    CoordinateType: Eq + Hash,
+    T: Eq + Hash,
 {
     /// Creates a non-owning iterator over the series of immutable live cell positions on the board in arbitrary order.
     ///
@@ -175,16 +175,16 @@ where
     /// ```
     ///
     #[inline]
-    pub fn iter(&'a self) -> hash_set::Iter<'a, Position<CoordinateType>> {
+    pub fn iter(&'a self) -> hash_set::Iter<'a, Position<T>> {
         self.into_iter()
     }
 }
 
 // Trait implementations
 
-impl<CoordinateType> Default for Board<CoordinateType>
+impl<T> Default for Board<T>
 where
-    CoordinateType: Eq + Hash,
+    T: Eq + Hash,
 {
     /// Returns the default value of the type, same as the return value of [`new()`].
     ///
@@ -195,9 +195,9 @@ where
     }
 }
 
-impl<CoordinateType> fmt::Display for Board<CoordinateType>
+impl<T> fmt::Display for Board<T>
 where
-    CoordinateType: Eq + Hash + Copy + PartialOrd + Zero + One + ToPrimitive,
+    T: Eq + Hash + Copy + PartialOrd + Zero + One + ToPrimitive,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let bbox = self.bounding_box();
@@ -211,12 +211,12 @@ where
     }
 }
 
-impl<'a, CoordinateType> IntoIterator for &'a Board<CoordinateType>
+impl<'a, T> IntoIterator for &'a Board<T>
 where
-    CoordinateType: Eq + Hash,
+    T: Eq + Hash,
 {
-    type Item = &'a Position<CoordinateType>;
-    type IntoIter = hash_set::Iter<'a, Position<CoordinateType>>;
+    type Item = &'a Position<T>;
+    type IntoIter = hash_set::Iter<'a, Position<T>>;
 
     /// Creates a non-owning iterator over the series of immutable live cell positions on the board in arbitrary order.
     ///
@@ -238,11 +238,11 @@ where
     }
 }
 
-impl<CoordinateType> IntoIterator for Board<CoordinateType>
+impl<T> IntoIterator for Board<T>
 where
-    CoordinateType: Eq + Hash,
+    T: Eq + Hash,
 {
-    type Item = Position<CoordinateType>;
+    type Item = Position<T>;
     type IntoIter = hash_set::IntoIter<Self::Item>;
 
     /// Creates an owning iterator over the series of moved live cell positions on the board in arbitrary order.
@@ -265,11 +265,11 @@ where
     }
 }
 
-impl<'a, CoordinateType> FromIterator<&'a Position<CoordinateType>> for Board<CoordinateType>
+impl<'a, T> FromIterator<&'a Position<T>> for Board<T>
 where
-    CoordinateType: Eq + Hash + Copy + 'a,
+    T: Eq + Hash + Copy + 'a,
 {
-    /// Conversion from a non-owning iterator over a series of `&Position<CoordinateType>`.
+    /// Conversion from a non-owning iterator over a series of `&Position<T>`.
     /// Each item in the series represents an immutable reference of a live cell position.
     ///
     /// # Examples
@@ -285,19 +285,19 @@ where
     /// ```
     ///
     #[inline]
-    fn from_iter<T>(iter: T) -> Self
+    fn from_iter<U>(iter: U) -> Self
     where
-        T: IntoIterator<Item = &'a Position<CoordinateType>>,
+        U: IntoIterator<Item = &'a Position<T>>,
     {
         Self::from_iter(iter.into_iter().copied())
     }
 }
 
-impl<CoordinateType> FromIterator<Position<CoordinateType>> for Board<CoordinateType>
+impl<T> FromIterator<Position<T>> for Board<T>
 where
-    CoordinateType: Eq + Hash,
+    T: Eq + Hash,
 {
-    /// Conversion from an owning iterator over a series of `Position<CoordinateType>`.
+    /// Conversion from an owning iterator over a series of `Position<T>`.
     /// Each item in the series represents a moved live cell position.
     ///
     /// # Examples
@@ -312,20 +312,20 @@ where
     /// assert_eq!(board.get(&Position(1, 1)), false);
     /// ```
     ///
-    fn from_iter<T>(iter: T) -> Self
+    fn from_iter<U>(iter: U) -> Self
     where
-        T: IntoIterator<Item = Position<CoordinateType>>,
+        U: IntoIterator<Item = Position<T>>,
     {
         let live_cells: HashSet<_, _> = iter.into_iter().collect();
         Self(live_cells)
     }
 }
 
-impl<'a, CoordinateType> Extend<&'a Position<CoordinateType>> for Board<CoordinateType>
+impl<'a, T> Extend<&'a Position<T>> for Board<T>
 where
-    CoordinateType: Eq + Hash + Copy + 'a,
+    T: Eq + Hash + Copy + 'a,
 {
-    /// Extend the board with the contents of the specified non-owning iterator over the series of `&Position<CoordinateType>`.
+    /// Extend the board with the contents of the specified non-owning iterator over the series of `&Position<T>`.
     /// Each item in the series represents an immutable reference of a live cell position.
     ///
     /// # Examples
@@ -342,19 +342,19 @@ where
     /// ```
     ///
     #[inline]
-    fn extend<T>(&mut self, iter: T)
+    fn extend<U>(&mut self, iter: U)
     where
-        T: IntoIterator<Item = &'a Position<CoordinateType>>,
+        U: IntoIterator<Item = &'a Position<T>>,
     {
         self.0.extend(iter);
     }
 }
 
-impl<CoordinateType> Extend<Position<CoordinateType>> for Board<CoordinateType>
+impl<T> Extend<Position<T>> for Board<T>
 where
-    CoordinateType: Eq + Hash,
+    T: Eq + Hash,
 {
-    /// Extend the board with the contents of the specified owning iterator over the series of `Position<CoordinateType>`.
+    /// Extend the board with the contents of the specified owning iterator over the series of `Position<T>`.
     /// Each item in the series represents a moved live cell position.
     ///
     /// # Examples
@@ -371,9 +371,9 @@ where
     /// ```
     ///
     #[inline]
-    fn extend<T>(&mut self, iter: T)
+    fn extend<U>(&mut self, iter: U)
     where
-        T: IntoIterator<Item = Position<CoordinateType>>,
+        U: IntoIterator<Item = Position<T>>,
     {
         self.0.extend(iter);
     }

--- a/src/board.rs
+++ b/src/board.rs
@@ -31,12 +31,9 @@ type DefaultCoordinateType = i16;
 /// ```
 ///
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Board<CoordinateType = DefaultCoordinateType>
+pub struct Board<CoordinateType = DefaultCoordinateType>(HashSet<Position<CoordinateType>, FnvBuildHasher>)
 where
-    CoordinateType: Eq + Hash,
-{
-    live_cells: HashSet<Position<CoordinateType>, FnvBuildHasher>,
-}
+    CoordinateType: Eq + Hash;
 
 // Inherent methods
 
@@ -56,8 +53,7 @@ where
     ///
     #[inline]
     pub fn new() -> Self {
-        let live_cells = HashSet::default();
-        Self { live_cells }
+        Self(HashSet::default())
     }
 
     /// Returns the value of the specified position of the board.
@@ -72,7 +68,7 @@ where
     ///
     #[inline]
     pub fn get(&self, position: &Position<CoordinateType>) -> bool {
-        self.live_cells.contains(position)
+        self.0.contains(position)
     }
 
     /// Set the specified value on the specified position of the board.
@@ -91,9 +87,9 @@ where
         CoordinateType: Copy,
     {
         if value {
-            self.live_cells.insert(*position);
+            self.0.insert(*position);
         } else {
-            self.live_cells.remove(position);
+            self.0.remove(position);
         }
     }
 
@@ -116,7 +112,7 @@ where
     where
         CoordinateType: Copy + PartialOrd + Zero,
     {
-        let mut iter = self.live_cells.iter();
+        let mut iter = self.0.iter();
         if let Some(&Position(init_x, init_y)) = iter.next() {
             Some(iter.fold((init_x, init_x, init_y, init_y), |(x_min, x_max, y_min, y_max), &Position(x, y)| {
                 (
@@ -145,7 +141,7 @@ where
     ///
     #[inline]
     pub fn clear(&mut self) {
-        self.live_cells.clear();
+        self.0.clear();
     }
 
     /// Retains only the live cell positions specified by the predicate, similar as `retain()` of `HashSet`.
@@ -169,7 +165,7 @@ where
     where
         F: FnMut(&Position<CoordinateType>) -> bool,
     {
-        self.live_cells.retain(pred);
+        self.0.retain(pred);
     }
 }
 
@@ -252,7 +248,7 @@ where
     ///
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
-        self.live_cells.iter()
+        self.0.iter()
     }
 }
 
@@ -279,7 +275,7 @@ where
     ///
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
-        self.live_cells.into_iter()
+        self.0.into_iter()
     }
 }
 
@@ -307,7 +303,7 @@ where
         T: IntoIterator<Item = &'a Position<CoordinateType>>,
     {
         let live_cells: HashSet<_, _> = iter.into_iter().copied().collect();
-        Self { live_cells }
+        Self(live_cells)
     }
 }
 
@@ -335,7 +331,7 @@ where
         T: IntoIterator<Item = Position<CoordinateType>>,
     {
         let live_cells: HashSet<_, _> = iter.into_iter().collect();
-        Self { live_cells }
+        Self(live_cells)
     }
 }
 
@@ -364,7 +360,7 @@ where
     where
         T: IntoIterator<Item = &'a Position<CoordinateType>>,
     {
-        self.live_cells.extend(iter);
+        self.0.extend(iter);
     }
 }
 
@@ -393,6 +389,6 @@ where
     where
         T: IntoIterator<Item = Position<CoordinateType>>,
     {
-        self.live_cells.extend(iter);
+        self.0.extend(iter);
     }
 }

--- a/src/board.rs
+++ b/src/board.rs
@@ -201,7 +201,9 @@ impl<CoordinateType> Default for Board<CoordinateType>
 where
     CoordinateType: Eq + Hash,
 {
-    /// Returns the default value of the type, same as the return value of `new()`.
+    /// Returns the default value of the type, same as the return value of [`new()`].
+    ///
+    /// [`new()`]: #method.new
     #[inline]
     fn default() -> Self {
         Self::new()

--- a/src/board.rs
+++ b/src/board.rs
@@ -300,12 +300,12 @@ where
     /// assert_eq!(board.get(&Position(1, 1)), false);
     /// ```
     ///
+    #[inline]
     fn from_iter<T>(iter: T) -> Self
     where
         T: IntoIterator<Item = &'a Position<CoordinateType>>,
     {
-        let live_cells: HashSet<_, _> = iter.into_iter().copied().collect();
-        Self(live_cells)
+        Self::from_iter(iter.into_iter().copied())
     }
 }
 

--- a/src/board.rs
+++ b/src/board.rs
@@ -8,7 +8,7 @@ use std::hash::Hash;
 
 use crate::{BoardRange, Position};
 
-/// A representation of a two-dimensional orthogonal grid map of live/dead cells.
+/// A two-dimensional orthogonal grid map of live/dead cells.
 ///
 /// The type parameter `T` is used as the type of the x- and y-coordinate values for each cell.
 ///
@@ -129,7 +129,10 @@ where
         self.0.clear();
     }
 
-    /// Retains only the live cell positions specified by the predicate, similar as `retain()` of `HashSet`.
+    /// Retains only the live cell positions specified by the predicate, similar as [`retain()`] of [`HashSet`].
+    ///
+    /// [`retain()`]: std::collections::HashSet::retain
+    /// [`HashSet`]: std::collections::HashSet
     ///
     /// # Examples
     ///
@@ -189,6 +192,7 @@ where
     /// Returns the default value of the type, same as the return value of [`new()`].
     ///
     /// [`new()`]: #method.new
+    ///
     #[inline]
     fn default() -> Self {
         Self::new()
@@ -269,8 +273,10 @@ impl<'a, T> FromIterator<&'a Position<T>> for Board<T>
 where
     T: Eq + Hash + Copy + 'a,
 {
-    /// Conversion from a non-owning iterator over a series of `&Position<T>`.
+    /// Creates a value from a non-owning iterator over a series of [`&Position<T>`].
     /// Each item in the series represents an immutable reference of a live cell position.
+    ///
+    /// [`&Position<T>`]: Position
     ///
     /// # Examples
     ///
@@ -297,8 +303,10 @@ impl<T> FromIterator<Position<T>> for Board<T>
 where
     T: Eq + Hash,
 {
-    /// Conversion from an owning iterator over a series of `Position<T>`.
+    /// Creates a value from an owning iterator over a series of [`Position<T>`].
     /// Each item in the series represents a moved live cell position.
+    ///
+    /// [`Position<T>`]: Position
     ///
     /// # Examples
     ///
@@ -325,8 +333,10 @@ impl<'a, T> Extend<&'a Position<T>> for Board<T>
 where
     T: Eq + Hash + Copy + 'a,
 {
-    /// Extend the board with the contents of the specified non-owning iterator over the series of `&Position<T>`.
+    /// Extends the board with the contents of the specified non-owning iterator over the series of [`&Position<T>`].
     /// Each item in the series represents an immutable reference of a live cell position.
+    ///
+    /// [`&Position<T>`]: Position
     ///
     /// # Examples
     ///
@@ -354,8 +364,10 @@ impl<T> Extend<Position<T>> for Board<T>
 where
     T: Eq + Hash,
 {
-    /// Extend the board with the contents of the specified owning iterator over the series of `Position<T>`.
+    /// Extends the board with the contents of the specified owning iterator over the series of [`Position<T>`].
     /// Each item in the series represents a moved live cell position.
+    ///
+    /// [`Position<T>`]: Position
     ///
     /// # Examples
     ///

--- a/src/board.rs
+++ b/src/board.rs
@@ -8,9 +8,6 @@ use std::hash::Hash;
 
 use crate::{BoardRange, Position};
 
-/// The default coordinate type of `Board`.
-type DefaultCoordinateType = i16;
-
 /// A representation of a two-dimensional orthogonal grid map of live/dead cells.
 ///
 /// The type parameter `CoordinateType` is used as the type of the x- and y-coordinate values for each cell.
@@ -31,7 +28,7 @@ type DefaultCoordinateType = i16;
 /// ```
 ///
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Board<CoordinateType = DefaultCoordinateType>(HashSet<Position<CoordinateType>, FnvBuildHasher>)
+pub struct Board<CoordinateType>(HashSet<Position<CoordinateType>, FnvBuildHasher>)
 where
     CoordinateType: Eq + Hash;
 

--- a/src/board.rs
+++ b/src/board.rs
@@ -166,8 +166,8 @@ where
     /// # Examples
     ///
     /// ```
-    /// use life_backend::{Board, Position};
     /// use std::collections::HashSet;
+    /// use life_backend::{Board, Position};
     /// let mut board = Board::<i16>::new();
     /// board.set(&Position(1, 0), true);
     /// board.set(&Position(0, 1), true);
@@ -227,8 +227,8 @@ where
     /// # Examples
     ///
     /// ```
-    /// use life_backend::{Board, Position};
     /// use std::collections::HashSet;
+    /// use life_backend::{Board, Position};
     /// let pattern = [Position(1, 0), Position(0, 1)];
     /// let board: Board<i16> = pattern.iter().collect();
     /// let result: HashSet<_> = (&board).into_iter().collect();
@@ -254,8 +254,8 @@ where
     /// # Examples
     ///
     /// ```
-    /// use life_backend::{Board, Position};
     /// use std::collections::HashSet;
+    /// use life_backend::{Board, Position};
     /// let pattern = [Position(1, 0), Position(0, 1)];
     /// let board: Board<i16> = pattern.iter().collect();
     /// let result: HashSet<_> = board.into_iter().collect();

--- a/src/board.rs
+++ b/src/board.rs
@@ -320,12 +320,12 @@ where
     /// assert_eq!(board.get(&Position(1, 1)), false);
     /// ```
     ///
+    #[inline]
     fn from_iter<U>(iter: U) -> Self
     where
         U: IntoIterator<Item = Position<T>>,
     {
-        let live_cells: HashSet<_, _> = iter.into_iter().collect();
-        Self(live_cells)
+        Self(HashSet::<Position<T>, _>::from_iter(iter))
     }
 }
 

--- a/src/boardrange.rs
+++ b/src/boardrange.rs
@@ -4,7 +4,7 @@ use std::ops::RangeInclusive;
 
 use crate::Position;
 
-/// A representation of a range on a board.
+/// A range on a board.
 ///
 /// The type parameter `T` is used as the type of the x- and y-coordinate values.
 ///
@@ -30,7 +30,7 @@ pub struct BoardRange<T>(RangeInclusive<T>, RangeInclusive<T>);
 // Inherent methods
 
 impl<T> BoardRange<T> {
-    /// Creates an empty `BoardRange`.
+    /// Creates an empty range.
     ///
     /// # Examples
     ///
@@ -109,7 +109,9 @@ impl<T> BoardRange<T> {
         &self.1
     }
 
-    /// Destructures the `BoardRange` into (range-x, range-y).
+    /// Destructures [`BoardRange`] into (range-x, range-y).
+    ///
+    /// [`BoardRange`]: BoardRange
     ///
     /// # Examples
     ///
@@ -162,6 +164,7 @@ where
     /// Returns the default value of the type, same as the return value of [`new()`].
     ///
     /// [`new()`]: #method.new
+    ///
     #[inline]
     fn default() -> Self {
         Self::new()
@@ -193,8 +196,10 @@ impl<'a, T> FromIterator<&'a Position<T>> for BoardRange<T>
 where
     T: Copy + PartialOrd + Zero + One + 'a,
 {
-    /// Conversion from a non-owning iterator over a series of `&Position<T>`.
+    /// Creates a value from a non-owning iterator over a series of [`&Position<T>`].
     /// Each item in the series represents an immutable reference of a position to be contained to the range.
+    ///
+    /// [`&Position<T>`]: Position
     ///
     /// # Examples
     ///
@@ -220,8 +225,10 @@ impl<T> FromIterator<Position<T>> for BoardRange<T>
 where
     T: Copy + PartialOrd + Zero + One,
 {
-    /// Conversion from an owning iterator over a series of `Position<T>`.
+    /// Creates a value from an owning iterator over a series of [`Position<T>`].
     /// Each item in the series represents a moved position to be contained to the range.
+    ///
+    /// [`Position<T>`]: Position
     ///
     /// # Examples
     ///
@@ -247,8 +254,10 @@ impl<'a, T> Extend<&'a Position<T>> for BoardRange<T>
 where
     T: Copy + PartialOrd + Zero + One + 'a,
 {
-    /// Extend the range with the contents of the specified non-owning iterator over the series of `&Position<T>`.
+    /// Extends the range with the contents of the specified non-owning iterator over the series of [`&Position<T>`].
     /// Each item in the series represents an immutable reference of a position.
+    ///
+    /// [`&Position<T>`]: Position
     ///
     /// # Examples
     ///
@@ -274,8 +283,10 @@ impl<T> Extend<Position<T>> for BoardRange<T>
 where
     T: Copy + PartialOrd + Zero + One,
 {
-    /// Extend the range with the contents of the specified owning iterator over the series of `Position<T>`.
+    /// Extends the range with the contents of the specified owning iterator over the series of [`Position<T>`].
     /// Each item in the series represents a moved position.
+    ///
+    /// [`Position<T>`]: Position
     ///
     /// # Examples
     ///

--- a/src/boardrange.rs
+++ b/src/boardrange.rs
@@ -6,6 +6,8 @@ use crate::Position;
 
 /// A representation of a range on a board.
 ///
+/// The type parameter `T` is used as the type of the x- and y-coordinate values.
+///
 /// # Examples
 ///
 /// ```

--- a/src/format.rs
+++ b/src/format.rs
@@ -53,14 +53,15 @@ where
     let ext = path
         .as_ref()
         .extension()
-        .map(|s| s.to_str().unwrap_or_default())
         .with_context(|| format!("\"{}\" has no extension", path_to_display))?
-        .to_string();
+        .to_os_string();
     let file = File::open(path).with_context(|| format!("Failed to open \"{}\"", path_to_display))?;
-    let result: Box<dyn Format> = match &ext[..] {
-        "cells" => Box::new(Plaintext::new(file)?),
-        "rle" => Box::new(Rle::new(file)?),
-        _ => bail!("\"{}\" has unknown extension", path_to_display),
+    let result: Box<dyn Format> = if ext.as_os_str() == "cells" {
+        Box::new(Plaintext::new(file)?)
+    } else if ext.as_os_str() == "rle" {
+        Box::new(Rle::new(file)?)
+    } else {
+        bail!("\"{}\" has unknown extension", path_to_display);
     };
     Ok(result)
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -25,8 +25,8 @@ pub trait Format: fmt::Display {
 /// use life_backend::format;
 /// use life_backend::Rule;
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let path_str = concat!(env!("CARGO_MANIFEST_DIR"), "/patterns/rpentomino.cells");
-/// let handler = format::open(path_str)?;
+/// let path = "patterns/rpentomino.cells";
+/// let handler = format::open(path)?;
 /// assert_eq!(handler.rule(), Rule::conways_life());
 /// assert_eq!(handler.live_cells().count(), 5);
 /// # Ok(())
@@ -37,8 +37,8 @@ pub trait Format: fmt::Display {
 /// use life_backend::format;
 /// use life_backend::Rule;
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let path_str = concat!(env!("CARGO_MANIFEST_DIR"), "/patterns/bheptomino.rle");
-/// let handler = format::open(path_str)?;
+/// let path = "patterns/bheptomino.rle";
+/// let handler = format::open(path)?;
 /// assert_eq!(handler.rule(), Rule::conways_life());
 /// assert_eq!(handler.live_cells().count(), 7);
 /// # Ok(())

--- a/src/format.rs
+++ b/src/format.rs
@@ -17,7 +17,7 @@ pub trait Format: fmt::Display {
     fn live_cells(&self) -> Box<dyn Iterator<Item = (usize, usize)> + '_>;
 }
 
-/// Attempts to open a file with the file format hander specified by the file extension.
+/// Attempts to open a file with the file format handler specified by the file extension.
 ///
 /// # Examples
 ///

--- a/src/format.rs
+++ b/src/format.rs
@@ -49,19 +49,19 @@ pub fn open<P>(path: P) -> Result<Box<dyn Format>>
 where
     P: AsRef<Path>,
 {
-    let path_to_display = path.as_ref().display().to_string();
+    let path_for_display = path.as_ref().to_owned();
     let ext = path
         .as_ref()
         .extension()
-        .with_context(|| format!("\"{}\" has no extension", path_to_display))?
-        .to_os_string();
-    let file = File::open(path).with_context(|| format!("Failed to open \"{}\"", path_to_display))?;
+        .with_context(|| format!("\"{}\" has no extension", path_for_display.display()))?
+        .to_owned();
+    let file = File::open(path).with_context(|| format!("Failed to open \"{}\"", path_for_display.display()))?;
     let result: Box<dyn Format> = if ext.as_os_str() == "cells" {
         Box::new(Plaintext::new(file)?)
     } else if ext.as_os_str() == "rle" {
         Box::new(Rle::new(file)?)
     } else {
-        bail!("\"{}\" has unknown extension", path_to_display);
+        bail!("\"{}\" has unknown extension", path_for_display.display());
     };
     Ok(result)
 }

--- a/src/format/plaintext/builder.rs
+++ b/src/format/plaintext/builder.rs
@@ -76,7 +76,9 @@ where
     Name: PlaintextBuilderName,
     Comment: PlaintextBuilderComment,
 {
-    /// Builds the specified Plaintext value.
+    /// Builds the [`Plaintext`] value.
+    ///
+    /// [`Plaintext`]: Plaintext
     ///
     /// # Examples
     ///
@@ -151,7 +153,9 @@ where
     ///
     /// # Errors
     ///
-    /// Code that calls name() twice or more will fail at compile time.  For example:
+    /// Code that calls [`name()`] twice or more will fail at compile time.  For example:
+    ///
+    /// [`name()`]: #method.name
     ///
     /// ```compile_fail
     /// use life_backend::format::PlaintextBuilder;
@@ -167,7 +171,10 @@ where
     /// # }
     /// ```
     ///
-    /// build() returns an error if the string passed by name(str) includes multiple lines.  For example:
+    /// [`build()`] returns an error if the string passed by [`name()`] includes multiple lines.  For example:
+    ///
+    /// [`build()`]: #method.build
+    /// [`name()`]: #method.name
     ///
     /// ```should_panic
     /// use life_backend::format::PlaintextBuilder;
@@ -196,7 +203,11 @@ impl<Name> PlaintextBuilder<Name, PlaintextBuilderNoComment>
 where
     Name: PlaintextBuilderName,
 {
-    /// Set the comment.  If the argument includes newlines, the instance of Plaintext built by build() includes multiple comment lines.
+    /// Set the comment.
+    /// If the argument includes newlines, the instance of [`Plaintext`] built by [`build()`] includes multiple comment lines.
+    ///
+    /// [`Plaintext`]: Plaintext
+    /// [`build()`]: #method.build
     ///
     /// # Examples
     ///
@@ -218,7 +229,9 @@ where
     ///
     /// # Errors
     ///
-    /// Code that calls comment() twice or more will fail at compile time.  For example:
+    /// Code that calls [`comment()`] twice or more will fail at compile time.  For example:
+    ///
+    /// [`comment()`]: #method.comment
     ///
     /// ```compile_fail
     /// use life_backend::format::PlaintextBuilder;
@@ -262,7 +275,7 @@ impl PlaintextBuilder<PlaintextBuilderNoName, PlaintextBuilderNoComment> {
 }
 
 impl<'a> FromIterator<&'a (usize, usize)> for PlaintextBuilder<PlaintextBuilderNoName, PlaintextBuilderNoComment> {
-    /// Conversion from a non-owning iterator over a series of &(usize, usize).
+    /// Conversion from a non-owning iterator over a series of `&(usize, usize)`.
     /// Each item in the series represents an immutable reference of a live cell position.
     ///
     /// # Examples
@@ -284,7 +297,7 @@ impl<'a> FromIterator<&'a (usize, usize)> for PlaintextBuilder<PlaintextBuilderN
 }
 
 impl FromIterator<(usize, usize)> for PlaintextBuilder<PlaintextBuilderNoName, PlaintextBuilderNoComment> {
-    /// Conversion from an owning iterator over a series of (usize, usize).
+    /// Conversion from an owning iterator over a series of `(usize, usize)`.
     /// Each item in the series represents a moved live cell position.
     ///
     /// # Examples

--- a/src/format/plaintext/builder.rs
+++ b/src/format/plaintext/builder.rs
@@ -275,7 +275,7 @@ impl PlaintextBuilder<PlaintextBuilderNoName, PlaintextBuilderNoComment> {
 }
 
 impl<'a> FromIterator<&'a (usize, usize)> for PlaintextBuilder<PlaintextBuilderNoName, PlaintextBuilderNoComment> {
-    /// Conversion from a non-owning iterator over a series of `&(usize, usize)`.
+    /// Creates a value from a non-owning iterator over a series of `&(usize, usize)`.
     /// Each item in the series represents an immutable reference of a live cell position.
     ///
     /// # Examples
@@ -297,7 +297,7 @@ impl<'a> FromIterator<&'a (usize, usize)> for PlaintextBuilder<PlaintextBuilderN
 }
 
 impl FromIterator<(usize, usize)> for PlaintextBuilder<PlaintextBuilderNoName, PlaintextBuilderNoComment> {
-    /// Conversion from an owning iterator over a series of `(usize, usize)`.
+    /// Creates a value from an owning iterator over a series of `(usize, usize)`.
     /// Each item in the series represents a moved live cell position.
     ///
     /// # Examples

--- a/src/format/plaintext/builder.rs
+++ b/src/format/plaintext/builder.rs
@@ -10,13 +10,43 @@ use crate::Position;
 ///
 /// # Examples
 ///
+/// Creates a builder via [`collect()`] with live cell positions, set a name via [`name()`], then builds [`Plaintext`] via [`build()`]:
+///
+/// [`collect()`]: std::iter::Iterator::collect
+/// [`name()`]: #method.name
+/// [`build()`]: #method.build
+///
 /// ```
 /// use life_backend::format::PlaintextBuilder;
 /// use life_backend::Position;
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let pattern = [Position(1, 0), Position(2, 0), Position(0, 1), Position(1, 1), Position(1, 2)];
-/// let builder: PlaintextBuilder = pattern.iter().collect();
-/// let target = builder.name("R-pentomino").build()?;
+/// let builder = pattern.iter().collect::<PlaintextBuilder>().name("R-pentomino");
+/// let target = builder.build()?;
+/// let expected = "\
+///     !Name: R-pentomino\n\
+///     .OO\n\
+///     OO.\n\
+///     .O.\n\
+/// ";
+/// assert_eq!(format!("{target}"), expected);
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Creates an empty builder via [`new()`], set a name via [`name()`], injects live cell positions via [`extend()`], then builds [`Plaintext`] via [`build()`]:
+///
+/// [`new()`]: #method.new
+/// [`extend()`]: #method.extend
+///
+/// ```
+/// use life_backend::format::PlaintextBuilder;
+/// use life_backend::Position;
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let pattern = [Position(1, 0), Position(2, 0), Position(0, 1), Position(1, 1), Position(1, 2)];
+/// let mut builder = PlaintextBuilder::new().name("R-pentomino");
+/// builder.extend(pattern.iter());
+/// let target = builder.build()?;
 /// let expected = "\
 ///     !Name: R-pentomino\n\
 ///     .OO\n\

--- a/src/format/plaintext/builder.rs
+++ b/src/format/plaintext/builder.rs
@@ -246,7 +246,7 @@ where
     /// ```
     ///
     pub fn name(self, str: &str) -> PlaintextBuilder<PlaintextBuilderWithName, Comment> {
-        let name = PlaintextBuilderWithName(str.to_string());
+        let name = PlaintextBuilderWithName(str.to_owned());
         PlaintextBuilder {
             name,
             comment: self.comment,
@@ -306,7 +306,7 @@ where
     /// ```
     ///
     pub fn comment(self, str: &str) -> PlaintextBuilder<Name, PlaintextBuilderWithComment> {
-        let comment = PlaintextBuilderWithComment(str.to_string());
+        let comment = PlaintextBuilderWithComment(str.to_owned());
         PlaintextBuilder {
             name: self.name,
             comment,

--- a/src/format/plaintext/builder.rs
+++ b/src/format/plaintext/builder.rs
@@ -226,6 +226,21 @@ where
 
 // Trait implementations
 
+impl PlaintextBuilder<PlaintextBuilderNoName, PlaintextBuilderNoComment> {
+    // Implementation of from_iter
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = (usize, usize)>,
+    {
+        let contents = iter.into_iter().collect();
+        Self {
+            name: PlaintextBuilderNoName,
+            comment: PlaintextBuilderNoComment,
+            contents,
+        }
+    }
+}
+
 impl<'a> FromIterator<&'a (usize, usize)> for PlaintextBuilder<PlaintextBuilderNoName, PlaintextBuilderNoComment> {
     /// Conversion from a non-owning iterator over a series of &(usize, usize).
     /// Each item in the series represents an immutable reference of a live cell position.
@@ -244,16 +259,12 @@ impl<'a> FromIterator<&'a (usize, usize)> for PlaintextBuilder<PlaintextBuilderN
     /// # }
     /// ```
     ///
+    #[inline]
     fn from_iter<T>(iter: T) -> Self
     where
         T: IntoIterator<Item = &'a (usize, usize)>,
     {
-        let contents = iter.into_iter().copied().collect();
-        Self {
-            name: PlaintextBuilderNoName,
-            comment: PlaintextBuilderNoComment,
-            contents,
-        }
+        Self::from_iter(iter.into_iter().copied())
     }
 }
 
@@ -275,15 +286,11 @@ impl FromIterator<(usize, usize)> for PlaintextBuilder<PlaintextBuilderNoName, P
     /// # }
     /// ```
     ///
+    #[inline]
     fn from_iter<T>(iter: T) -> Self
     where
         T: IntoIterator<Item = (usize, usize)>,
     {
-        let contents = iter.into_iter().collect();
-        Self {
-            name: PlaintextBuilderNoName,
-            comment: PlaintextBuilderNoComment,
-            contents,
-        }
+        Self::from_iter(iter)
     }
 }

--- a/src/format/plaintext/builder.rs
+++ b/src/format/plaintext/builder.rs
@@ -3,7 +3,29 @@ use std::collections::{HashMap, HashSet};
 
 use super::{Plaintext, PlaintextLine};
 
-/// A builder of Plaintext.
+/// A builder of [`Plaintext`].
+///
+/// [`Plaintext`]: Plaintext
+///
+/// # Examples
+///
+/// ```
+/// use life_backend::format::PlaintextBuilder;
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let pattern = [(1, 0), (2, 0), (0, 1), (1, 1), (1, 2)];
+/// let builder: PlaintextBuilder = pattern.iter().collect();
+/// let target = builder.name("R-pentomino").build()?;
+/// let expected = "\
+///     !Name: R-pentomino\n\
+///     .OO\n\
+///     OO.\n\
+///     .O.\n\
+/// ";
+/// assert_eq!(format!("{target}"), expected);
+/// # Ok(())
+/// # }
+/// ```
+///
 #[derive(Debug, Clone)]
 pub struct PlaintextBuilder<Name = PlaintextBuilderNoName, Comment = PlaintextBuilderNoComment>
 where

--- a/src/format/plaintext/builder.rs
+++ b/src/format/plaintext/builder.rs
@@ -62,10 +62,8 @@ where
     /// use life_backend::format::PlaintextBuilder;
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let pattern = [(1, 0), (0, 1)];
-    /// let target = pattern
-    ///     .iter()
-    ///     .collect::<PlaintextBuilder>()
-    ///     .build()?;
+    /// let builder: PlaintextBuilder = pattern.iter().collect();
+    /// let target = builder.build()?;
     /// # Ok(())
     /// # }
     /// ```
@@ -249,14 +247,9 @@ impl<'a> FromIterator<&'a (usize, usize)> for PlaintextBuilder<PlaintextBuilderN
     ///
     /// ```
     /// use life_backend::format::PlaintextBuilder;
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let pattern = [(1, 0), (0, 1)];
-    /// let builder = pattern
-    ///     .iter()
-    ///     .collect::<PlaintextBuilder>();
-    /// let target = builder.build()?;
-    /// # Ok(())
-    /// # }
+    /// let iter = pattern.iter();
+    /// let builder: PlaintextBuilder = iter.collect();
     /// ```
     ///
     #[inline]
@@ -276,14 +269,9 @@ impl FromIterator<(usize, usize)> for PlaintextBuilder<PlaintextBuilderNoName, P
     ///
     /// ```
     /// use life_backend::format::PlaintextBuilder;
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let pattern = [(1, 0), (0, 1)];
-    /// let builder = pattern
-    ///     .into_iter()
-    ///     .collect::<PlaintextBuilder>();
-    /// let target = builder.build()?;
-    /// # Ok(())
-    /// # }
+    /// let iter = pattern.into_iter();
+    /// let builder: PlaintextBuilder = iter.collect();
     /// ```
     ///
     #[inline]

--- a/src/format/plaintext/builder.rs
+++ b/src/format/plaintext/builder.rs
@@ -21,8 +21,7 @@ use crate::Position;
 /// use life_backend::Position;
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let pattern = [Position(1, 0), Position(2, 0), Position(0, 1), Position(1, 1), Position(1, 2)];
-/// let builder = pattern.iter().collect::<PlaintextBuilder>().name("R-pentomino");
-/// let target = builder.build()?;
+/// let target = pattern.iter().collect::<PlaintextBuilder>().name("R-pentomino").build()?;
 /// let expected = "\
 ///     !Name: R-pentomino\n\
 ///     .OO\n\

--- a/src/format/plaintext/core.rs
+++ b/src/format/plaintext/core.rs
@@ -20,7 +20,7 @@ use crate::{Format, Rule};
 /// use std::fs::File;
 /// use life_backend::format::Plaintext;
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let file = File::open(concat!(env!("CARGO_MANIFEST_DIR"), "/patterns/rpentomino.cells"))?;
+/// let file = File::open("patterns/rpentomino.cells")?;
 /// let parser = Plaintext::new(file)?;
 /// assert!(parser.live_cells().eq([(1, 0), (2, 0), (0, 1), (1, 1), (1, 2)]));
 /// # Ok(())

--- a/src/format/plaintext/core.rs
+++ b/src/format/plaintext/core.rs
@@ -12,6 +12,39 @@ use crate::{Format, Rule};
 ///
 /// - [Plaintext - LifeWiki](https://conwaylife.com/wiki/Plaintext)
 ///
+/// # Examples
+///
+/// Parses the given Plaintext file, and checks live cells included in it:
+///
+/// ```
+/// use std::fs::File;
+/// use std::path::Path;
+/// use life_backend::format::Plaintext;
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let file = File::open(concat!(env!("CARGO_MANIFEST_DIR"), "/patterns/rpentomino.cells"))?;
+/// let parser = Plaintext::new(file)?;
+/// assert!(parser.live_cells().eq([(1, 0), (2, 0), (0, 1), (1, 1), (1, 2)]));
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Parses the given string in Plaintext format:
+///
+/// ```
+/// use life_backend::format::Plaintext;
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let pattern = "\
+///     !Name: R-pentomino\n\
+///     .OO\n\
+///     OO.\n\
+///     .O.\n\
+/// ";
+/// let parser = pattern.parse::<Plaintext>()?;
+/// assert!(parser.live_cells().eq([(1, 0), (2, 0), (0, 1), (1, 1), (1, 2)]));
+/// # Ok(())
+/// # }
+/// ```
+///
 #[derive(Debug, Clone)]
 pub struct Plaintext {
     pub(super) name: Option<String>,

--- a/src/format/plaintext/core.rs
+++ b/src/format/plaintext/core.rs
@@ -96,7 +96,7 @@ impl Plaintext {
         &self.comments
     }
 
-    /// Creates a non-owning iterator over the series of immutable live cell positions in ascending order.
+    /// Creates an owning iterator over the series of live cell positions in ascending order.
     ///
     /// # Examples
     ///

--- a/src/format/plaintext/core.rs
+++ b/src/format/plaintext/core.rs
@@ -22,7 +22,10 @@ pub struct Plaintext {
 // Inherent methods
 
 impl Plaintext {
-    /// Creates from the specified implementor of Read, such as File or `&[u8]`.
+    /// Creates from the specified implementor of [`Read`], such as [`File`] or `&[u8]`.
+    ///
+    /// [`Read`]: std::io::Read
+    /// [`File`]: std::fs::File
     ///
     /// # Examples
     ///

--- a/src/format/plaintext/core.rs
+++ b/src/format/plaintext/core.rs
@@ -92,7 +92,7 @@ impl Plaintext {
     /// ```
     ///
     #[inline]
-    pub fn comments(&self) -> &Vec<String> {
+    pub const fn comments(&self) -> &Vec<String> {
         &self.comments
     }
 

--- a/src/format/plaintext/core.rs
+++ b/src/format/plaintext/core.rs
@@ -109,12 +109,7 @@ impl Plaintext {
     ///     .O.\n\
     /// ";
     /// let parser = Plaintext::new(pattern.as_bytes())?;
-    /// let mut iter = parser.live_cells();
-    /// assert_eq!(iter.next(), Some((0, 0)));
-    /// assert_eq!(iter.next(), Some((1, 0)));
-    /// assert_eq!(iter.next(), Some((2, 0)));
-    /// assert_eq!(iter.next(), Some((1, 1)));
-    /// assert_eq!(iter.next(), None);
+    /// assert!(parser.live_cells().eq([(0, 0), (1, 0), (2, 0), (1, 1)]));
     /// # Ok(())
     /// # }
     /// ```

--- a/src/format/plaintext/core.rs
+++ b/src/format/plaintext/core.rs
@@ -18,7 +18,6 @@ use crate::{Format, Rule};
 ///
 /// ```
 /// use std::fs::File;
-/// use std::path::Path;
 /// use life_backend::format::Plaintext;
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let file = File::open(concat!(env!("CARGO_MANIFEST_DIR"), "/patterns/rpentomino.cells"))?;

--- a/src/format/plaintext/parser.rs
+++ b/src/format/plaintext/parser.rs
@@ -45,13 +45,13 @@ impl PlaintextParser {
     fn push(&mut self, line: &str) -> Result<()> {
         if self.name.is_none() && self.comments.is_empty() && self.lines == 0 {
             if let Some(name) = Self::parse_name_line(line) {
-                self.name = Some(name.to_string());
+                self.name = Some(name.to_owned());
                 return Ok(());
             }
         }
         if self.lines == 0 {
             if let Some(comment) = Self::parse_comment_line(line) {
-                self.comments.push(comment.to_string());
+                self.comments.push(comment.to_owned());
                 return Ok(());
             }
         }

--- a/src/format/plaintext/tests.rs
+++ b/src/format/plaintext/tests.rs
@@ -38,73 +38,54 @@ fn do_from_str_test_to_be_passed(pattern: &str, expected_name: &Option<&str>, ex
 #[test]
 fn test_new_empty() -> Result<()> {
     let pattern = "";
-    let expected_name = None;
-    let expected_comments = Vec::new();
-    let expected_contents = Vec::new();
-    do_new_test_to_be_passed(pattern, &expected_name, &expected_comments, &expected_contents)
+    do_new_test_to_be_passed(pattern, &None, &Vec::new(), &Vec::new())
 }
 
 #[test]
 fn test_new_header() -> Result<()> {
     let pattern = "!Name: test\n";
-    let expected_name = Some("test");
-    let expected_comments = Vec::new();
-    let expected_contents = Vec::new();
-    do_new_test_to_be_passed(pattern, &expected_name, &expected_comments, &expected_contents)
+    do_new_test_to_be_passed(pattern, &Some("test"), &Vec::new(), &Vec::new())
 }
 
 #[test]
 fn test_new_no_header_but_comment() -> Result<()> {
     let pattern = "!comment\n";
-    let expected_name = None;
-    let expected_comments = vec!["comment"];
-    let expected_contents = Vec::new();
-    do_new_test_to_be_passed(pattern, &expected_name, &expected_comments, &expected_contents)
+    do_new_test_to_be_passed(pattern, &None, &["comment"], &Vec::new())
 }
 
 #[test]
 fn test_new_header_comment() -> Result<()> {
     let pattern = concat!("!Name: test\n", "!comment\n");
-    let expected_name = Some("test");
-    let expected_comments = vec!["comment"];
-    let expected_contents = Vec::new();
-    do_new_test_to_be_passed(pattern, &expected_name, &expected_comments, &expected_contents)
+    do_new_test_to_be_passed(pattern, &Some("test"), &["comment"], &Vec::new())
 }
 
 #[test]
 fn test_new_header_comments() -> Result<()> {
     let pattern = concat!("!Name: test\n", "!comment0\n", "!comment1\n");
-    let expected_name = Some("test");
-    let expected_comments = vec!["comment0", "comment1"];
-    let expected_contents = Vec::new();
-    do_new_test_to_be_passed(pattern, &expected_name, &expected_comments, &expected_contents)
+    do_new_test_to_be_passed(pattern, &Some("test"), &["comment0", "comment1"], &Vec::new())
 }
 
 #[test]
 fn test_new_header_content() -> Result<()> {
     let pattern = concat!("!Name: test\n", ".O\n");
-    let expected_name = Some("test");
-    let expected_comments = Vec::new();
-    let expected_contents = vec![PlaintextLine(0, vec![1])];
-    do_new_test_to_be_passed(pattern, &expected_name, &expected_comments, &expected_contents)
+    do_new_test_to_be_passed(pattern, &Some("test"), &Vec::new(), &[PlaintextLine(0, vec![1])])
 }
 
 #[test]
 fn test_new_header_contents() -> Result<()> {
     let pattern = concat!("!Name: test\n", ".O\n", "O.\n");
-    let expected_name = Some("test");
-    let expected_comments = Vec::new();
-    let expected_contents = vec![PlaintextLine(0, vec![1]), PlaintextLine(1, vec![0])];
-    do_new_test_to_be_passed(pattern, &expected_name, &expected_comments, &expected_contents)
+    do_new_test_to_be_passed(pattern, &Some("test"), &Vec::new(), &[PlaintextLine(0, vec![1]), PlaintextLine(1, vec![0])])
 }
 
 #[test]
 fn test_new_header_comments_contents() -> Result<()> {
     let pattern = concat!("!Name: test\n", "!comment0\n", "!comment1\n", ".O\n", "O.\n");
-    let expected_name = Some("test");
-    let expected_comments = vec!["comment0", "comment1"];
-    let expected_contents = vec![PlaintextLine(0, vec![1]), PlaintextLine(1, vec![0])];
-    do_new_test_to_be_passed(pattern, &expected_name, &expected_comments, &expected_contents)
+    do_new_test_to_be_passed(
+        pattern,
+        &Some("test"),
+        &["comment0", "comment1"],
+        &[PlaintextLine(0, vec![1]), PlaintextLine(1, vec![0])],
+    )
 }
 
 #[test]
@@ -116,10 +97,7 @@ fn test_new_wrong_header() {
 #[test]
 fn test_new_duplicate_header() -> Result<()> {
     let pattern = concat!("!Name: name0\n", "!Name: name1\n");
-    let expected_name = Some("name0");
-    let expected_comments = vec!["Name: name1"];
-    let expected_contents = Vec::new();
-    do_new_test_to_be_passed(pattern, &expected_name, &expected_comments, &expected_contents)
+    do_new_test_to_be_passed(pattern, &Some("name0"), &["Name: name1"], &Vec::new())
 }
 
 #[test]
@@ -137,33 +115,24 @@ fn test_new_wrong_content_with_comment() {
 #[test]
 fn test_build() -> Result<()> {
     let pattern = [Position(1, 0), Position(0, 1)];
-    let expected_name = None;
-    let expected_comments = Vec::new();
-    let expected_contents = vec![PlaintextLine(0, vec![1]), PlaintextLine(1, vec![0])];
     let target = pattern.iter().collect::<PlaintextBuilder>().build()?;
-    do_check(&target, &expected_name, &expected_comments, &expected_contents);
+    do_check(&target, &None, &Vec::new(), &[PlaintextLine(0, vec![1]), PlaintextLine(1, vec![0])]);
     Ok(())
 }
 
 #[test]
 fn test_build_singleline_name() -> Result<()> {
     let pattern = [Position(1, 0), Position(0, 1)];
-    let expected_name = Some("test");
-    let expected_comments = Vec::new();
-    let expected_contents = vec![PlaintextLine(0, vec![1]), PlaintextLine(1, vec![0])];
     let target = pattern.iter().collect::<PlaintextBuilder>().name("test").build()?;
-    do_check(&target, &expected_name, &expected_comments, &expected_contents);
+    do_check(&target, &Some("test"), &Vec::new(), &[PlaintextLine(0, vec![1]), PlaintextLine(1, vec![0])]);
     Ok(())
 }
 
 #[test]
 fn test_build_blank_name() -> Result<()> {
     let pattern = [Position(1, 0), Position(0, 1)];
-    let expected_name = Some("");
-    let expected_comments = Vec::new();
-    let expected_contents = vec![PlaintextLine(0, vec![1]), PlaintextLine(1, vec![0])];
     let target = pattern.iter().collect::<PlaintextBuilder>().name("").build()?;
-    do_check(&target, &expected_name, &expected_comments, &expected_contents);
+    do_check(&target, &Some(""), &Vec::new(), &[PlaintextLine(0, vec![1]), PlaintextLine(1, vec![0])]);
     Ok(())
 }
 
@@ -177,52 +146,47 @@ fn test_build_multiline_name() {
 #[test]
 fn test_build_comment() -> Result<()> {
     let pattern = [Position(1, 0), Position(0, 1)];
-    let expected_name = None;
-    let expected_comments = vec!["comment"];
-    let expected_contents = vec![PlaintextLine(0, vec![1]), PlaintextLine(1, vec![0])];
     let target = pattern.iter().collect::<PlaintextBuilder>().comment("comment").build()?;
-    do_check(&target, &expected_name, &expected_comments, &expected_contents);
+    do_check(&target, &None, &["comment"], &[PlaintextLine(0, vec![1]), PlaintextLine(1, vec![0])]);
     Ok(())
 }
 
 #[test]
 fn test_build_blank_comment() -> Result<()> {
     let pattern = [Position(1, 0), Position(0, 1)];
-    let expected_name = None;
-    let expected_comments = vec![""];
-    let expected_contents = vec![PlaintextLine(0, vec![1]), PlaintextLine(1, vec![0])];
     let target = pattern.iter().collect::<PlaintextBuilder>().comment("").build()?;
-    do_check(&target, &expected_name, &expected_comments, &expected_contents);
+    do_check(&target, &None, &[""], &[PlaintextLine(0, vec![1]), PlaintextLine(1, vec![0])]);
     Ok(())
 }
 
 #[test]
 fn test_build_comments() -> Result<()> {
     let pattern = [Position(1, 0), Position(0, 1)];
-    let expected_name = None;
-    let expected_comments = vec!["comment0", "comment1"];
-    let expected_contents = vec![PlaintextLine(0, vec![1]), PlaintextLine(1, vec![0])];
     let target = pattern.iter().collect::<PlaintextBuilder>().comment("comment0\ncomment1").build()?;
-    do_check(&target, &expected_name, &expected_comments, &expected_contents);
+    do_check(
+        &target,
+        &None,
+        &["comment0", "comment1"],
+        &[PlaintextLine(0, vec![1]), PlaintextLine(1, vec![0])],
+    );
     Ok(())
 }
 
 #[test]
 fn test_build_name_comment() -> Result<()> {
     let pattern = [Position(1, 0), Position(0, 1)];
-    let expected_name = Some("test");
-    let expected_comments = vec!["comment"];
-    let expected_contents = vec![PlaintextLine(0, vec![1]), PlaintextLine(1, vec![0])];
     let target = pattern.iter().collect::<PlaintextBuilder>().name("test").comment("comment").build()?;
-    do_check(&target, &expected_name, &expected_comments, &expected_contents);
+    do_check(&target, &Some("test"), &["comment"], &[PlaintextLine(0, vec![1]), PlaintextLine(1, vec![0])]);
     Ok(())
 }
 
 #[test]
 fn test_from_str() -> Result<()> {
     let pattern = concat!("!Name: test\n", "!comment0\n", "!comment1\n", ".O\n", "O.\n");
-    let expected_name = Some("test");
-    let expected_comments = vec!["comment0", "comment1"];
-    let expected_contents = vec![PlaintextLine(0, vec![1]), PlaintextLine(1, vec![0])];
-    do_from_str_test_to_be_passed(pattern, &expected_name, &expected_comments, &expected_contents)
+    do_from_str_test_to_be_passed(
+        pattern,
+        &Some("test"),
+        &["comment0", "comment1"],
+        &[PlaintextLine(0, vec![1]), PlaintextLine(1, vec![0])],
+    )
 }

--- a/src/format/plaintext/tests.rs
+++ b/src/format/plaintext/tests.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 
 use super::{Plaintext, PlaintextBuilder, PlaintextLine};
+use crate::Position;
 
 fn do_check(target: &Plaintext, expected_name: &Option<&str>, expected_comments: &[&str], expected_contents: &[PlaintextLine]) {
     let expected_name = expected_name.map(String::from);
@@ -135,7 +136,7 @@ fn test_new_wrong_content_with_comment() {
 
 #[test]
 fn test_build() -> Result<()> {
-    let pattern = [(1, 0), (0, 1)];
+    let pattern = [Position(1, 0), Position(0, 1)];
     let expected_name = None;
     let expected_comments = Vec::new();
     let expected_contents = vec![PlaintextLine(0, vec![1]), PlaintextLine(1, vec![0])];
@@ -146,7 +147,7 @@ fn test_build() -> Result<()> {
 
 #[test]
 fn test_build_singleline_name() -> Result<()> {
-    let pattern = [(1, 0), (0, 1)];
+    let pattern = [Position(1, 0), Position(0, 1)];
     let expected_name = Some("test");
     let expected_comments = Vec::new();
     let expected_contents = vec![PlaintextLine(0, vec![1]), PlaintextLine(1, vec![0])];
@@ -157,7 +158,7 @@ fn test_build_singleline_name() -> Result<()> {
 
 #[test]
 fn test_build_blank_name() -> Result<()> {
-    let pattern = [(1, 0), (0, 1)];
+    let pattern = [Position(1, 0), Position(0, 1)];
     let expected_name = Some("");
     let expected_comments = Vec::new();
     let expected_contents = vec![PlaintextLine(0, vec![1]), PlaintextLine(1, vec![0])];
@@ -168,14 +169,14 @@ fn test_build_blank_name() -> Result<()> {
 
 #[test]
 fn test_build_multiline_name() {
-    let pattern = [(1, 0), (0, 1)];
+    let pattern = [Position(1, 0), Position(0, 1)];
     let target = pattern.iter().collect::<PlaintextBuilder>().name("name\nname").build();
     assert!(target.is_err());
 }
 
 #[test]
 fn test_build_comment() -> Result<()> {
-    let pattern = [(1, 0), (0, 1)];
+    let pattern = [Position(1, 0), Position(0, 1)];
     let expected_name = None;
     let expected_comments = vec!["comment"];
     let expected_contents = vec![PlaintextLine(0, vec![1]), PlaintextLine(1, vec![0])];
@@ -186,7 +187,7 @@ fn test_build_comment() -> Result<()> {
 
 #[test]
 fn test_build_blank_comment() -> Result<()> {
-    let pattern = [(1, 0), (0, 1)];
+    let pattern = [Position(1, 0), Position(0, 1)];
     let expected_name = None;
     let expected_comments = vec![""];
     let expected_contents = vec![PlaintextLine(0, vec![1]), PlaintextLine(1, vec![0])];
@@ -197,7 +198,7 @@ fn test_build_blank_comment() -> Result<()> {
 
 #[test]
 fn test_build_comments() -> Result<()> {
-    let pattern = [(1, 0), (0, 1)];
+    let pattern = [Position(1, 0), Position(0, 1)];
     let expected_name = None;
     let expected_comments = vec!["comment0", "comment1"];
     let expected_contents = vec![PlaintextLine(0, vec![1]), PlaintextLine(1, vec![0])];
@@ -208,7 +209,7 @@ fn test_build_comments() -> Result<()> {
 
 #[test]
 fn test_build_name_comment() -> Result<()> {
-    let pattern = [(1, 0), (0, 1)];
+    let pattern = [Position(1, 0), Position(0, 1)];
     let expected_name = Some("test");
     let expected_comments = vec!["comment"];
     let expected_contents = vec![PlaintextLine(0, vec![1]), PlaintextLine(1, vec![0])];

--- a/src/format/rle/builder.rs
+++ b/src/format/rle/builder.rs
@@ -4,7 +4,28 @@ use std::collections::{HashMap, HashSet};
 use super::{Rle, RleHeader, RleRunsTriple};
 use crate::Rule;
 
-/// A builder of Rle.
+/// A builder of [`Rle`].
+///
+/// [`Rle`]: Rle
+///
+/// # Examples
+///
+/// ```
+/// use life_backend::format::RleBuilder;
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let pattern = [(1, 0), (2, 0), (0, 1), (1, 1), (1, 2)];
+/// let builder = pattern.iter().collect::<RleBuilder>();
+/// let target = builder.name("R-pentomino").build()?;
+/// let expected = "\
+///     #N R-pentomino\n\
+///     x = 3, y = 3, rule = B3/S23\n\
+///     b2o$2o$bo!\n\
+/// ";
+/// assert_eq!(format!("{target}"), expected);
+/// # Ok(())
+/// # }
+/// ```
+///
 #[derive(Debug, Clone)]
 pub struct RleBuilder<Name = RleBuilderNoName, Created = RleBuilderNoCreated, Comment = RleBuilderNoComment, Rule = RleBuilderNoRule>
 where

--- a/src/format/rle/builder.rs
+++ b/src/format/rle/builder.rs
@@ -10,13 +10,42 @@ use crate::{Position, Rule};
 ///
 /// # Examples
 ///
+/// Creates a builder via [`collect()`] with live cell positions, set a name via [`name()`], then builds [`Rle`] via [`build()`]:
+///
+/// [`collect()`]: std::iter::Iterator::collect
+/// [`name()`]: #method.name
+/// [`build()`]: #method.build
+///
 /// ```
 /// use life_backend::format::RleBuilder;
 /// use life_backend::Position;
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let pattern = [Position(1, 0), Position(2, 0), Position(0, 1), Position(1, 1), Position(1, 2)];
-/// let builder = pattern.iter().collect::<RleBuilder>();
-/// let target = builder.name("R-pentomino").build()?;
+/// let builder = pattern.iter().collect::<RleBuilder>().name("R-pentomino");
+/// let target = builder.build()?;
+/// let expected = "\
+///     #N R-pentomino\n\
+///     x = 3, y = 3, rule = B3/S23\n\
+///     b2o$2o$bo!\n\
+/// ";
+/// assert_eq!(format!("{target}"), expected);
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Creates an empty builder via [`new()`], set a name via [`name()`], injects live cell positions via [`extend()`], then builds [`Rle`] via [`build()`]:
+///
+/// [`new()`]: #method.new
+/// [`extend()`]: #method.extend
+///
+/// ```
+/// use life_backend::format::RleBuilder;
+/// use life_backend::Position;
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let pattern = [Position(1, 0), Position(2, 0), Position(0, 1), Position(1, 1), Position(1, 2)];
+/// let mut builder = RleBuilder::new().name("R-pentomino");
+/// builder.extend(pattern.iter());
+/// let target = builder.build()?;
 /// let expected = "\
 ///     #N R-pentomino\n\
 ///     x = 3, y = 3, rule = B3/S23\n\

--- a/src/format/rle/builder.rs
+++ b/src/format/rle/builder.rs
@@ -185,7 +185,7 @@ where
         let comments: Vec<_> = {
             fn parse_to_comments(str: Option<String>, prefix: &str) -> Vec<String> {
                 fn append_prefix(str: &str, prefix: &str) -> String {
-                    let mut buf = prefix.to_string();
+                    let mut buf = prefix.to_owned();
                     if !str.is_empty() {
                         buf.push(' ');
                         buf.push_str(str);
@@ -195,7 +195,7 @@ where
                 match str {
                     Some(str) => {
                         if str.is_empty() {
-                            vec![prefix.to_string()]
+                            vec![prefix.to_owned()]
                         } else {
                             str.lines().map(|s| append_prefix(s, prefix)).collect::<Vec<_>>()
                         }
@@ -328,7 +328,7 @@ where
     /// ```
     ///
     pub fn name(self, str: &str) -> RleBuilder<RleBuilderWithName, Created, Comment, Rule> {
-        let name = RleBuilderWithName(str.to_string());
+        let name = RleBuilderWithName(str.to_owned());
         RleBuilder {
             name,
             created: self.created,
@@ -391,7 +391,7 @@ where
     /// ```
     ///
     pub fn created(self, str: &str) -> RleBuilder<Name, RleBuilderWithCreated, Comment, Rule> {
-        let created = RleBuilderWithCreated(str.to_string());
+        let created = RleBuilderWithCreated(str.to_owned());
         RleBuilder {
             name: self.name,
             created,
@@ -455,7 +455,7 @@ where
     /// ```
     ///
     pub fn comment(self, str: &str) -> RleBuilder<Name, Created, RleBuilderWithComment, Rule> {
-        let comment = RleBuilderWithComment(str.to_string());
+        let comment = RleBuilderWithComment(str.to_owned());
         RleBuilder {
             name: self.name,
             created: self.created,

--- a/src/format/rle/builder.rs
+++ b/src/format/rle/builder.rs
@@ -21,8 +21,7 @@ use crate::{Position, Rule};
 /// use life_backend::Position;
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let pattern = [Position(1, 0), Position(2, 0), Position(0, 1), Position(1, 1), Position(1, 2)];
-/// let builder = pattern.iter().collect::<RleBuilder>().name("R-pentomino");
-/// let target = builder.build()?;
+/// let target = pattern.iter().collect::<RleBuilder>().name("R-pentomino").build()?;
 /// let expected = "\
 ///     #N R-pentomino\n\
 ///     x = 3, y = 3, rule = B3/S23\n\

--- a/src/format/rle/builder.rs
+++ b/src/format/rle/builder.rs
@@ -484,7 +484,7 @@ impl RleBuilder<RleBuilderNoName, RleBuilderNoCreated, RleBuilderNoComment, RleB
 }
 
 impl<'a> FromIterator<&'a (usize, usize)> for RleBuilder<RleBuilderNoName, RleBuilderNoCreated, RleBuilderNoComment, RleBuilderNoRule> {
-    /// Conversion from a non-owning iterator over a series of `&(usize, usize)`.
+    /// Creates a value from a non-owning iterator over a series of `&(usize, usize)`.
     /// Each item in the series represents an immutable reference of a live cell position.
     ///
     /// # Examples
@@ -506,7 +506,7 @@ impl<'a> FromIterator<&'a (usize, usize)> for RleBuilder<RleBuilderNoName, RleBu
 }
 
 impl FromIterator<(usize, usize)> for RleBuilder<RleBuilderNoName, RleBuilderNoCreated, RleBuilderNoComment, RleBuilderNoRule> {
-    /// Conversion from an owning iterator over a series of `(usize, usize)`.
+    /// Creates a value from an owning iterator over a series of `(usize, usize)`.
     /// Each item in the series represents a moved live cell position.
     ///
     /// # Examples

--- a/src/format/rle/builder.rs
+++ b/src/format/rle/builder.rs
@@ -2,7 +2,7 @@ use anyhow::{ensure, Result};
 use std::collections::{HashMap, HashSet};
 
 use super::{Rle, RleHeader, RleRunsTriple};
-use crate::Rule;
+use crate::{Position, Rule};
 
 /// A builder of [`Rle`].
 ///
@@ -12,8 +12,9 @@ use crate::Rule;
 ///
 /// ```
 /// use life_backend::format::RleBuilder;
+/// use life_backend::Position;
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let pattern = [(1, 0), (2, 0), (0, 1), (1, 1), (1, 2)];
+/// let pattern = [Position(1, 0), Position(2, 0), Position(0, 1), Position(1, 1), Position(1, 2)];
 /// let builder = pattern.iter().collect::<RleBuilder>();
 /// let target = builder.name("R-pentomino").build()?;
 /// let expected = "\
@@ -38,7 +39,7 @@ where
     created: Created,
     comment: Comment,
     rule: Rule,
-    contents: HashSet<(usize, usize)>,
+    contents: HashSet<Position<usize>>,
 }
 
 // Traits and types for RleBuilder's typestate
@@ -120,8 +121,9 @@ where
     ///
     /// ```
     /// use life_backend::format::RleBuilder;
+    /// use life_backend::Position;
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let pattern = [(1, 0), (0, 1)];
+    /// let pattern = [Position(1, 0), Position(0, 1)];
     /// let builder: RleBuilder = pattern.iter().collect();
     /// let target = builder.build()?;
     /// # Ok(())
@@ -160,7 +162,7 @@ where
                 .collect()
         };
         let rule = self.rule.drain().unwrap_or(Rule::conways_life());
-        let contents_group_by_y = self.contents.into_iter().fold(HashMap::new(), |mut acc, (x, y)| {
+        let contents_group_by_y = self.contents.into_iter().fold(HashMap::new(), |mut acc, Position(x, y)| {
             acc.entry(y).or_insert_with(Vec::new).push(x);
             acc
         });
@@ -220,8 +222,9 @@ where
     ///
     /// ```
     /// use life_backend::format::RleBuilder;
+    /// use life_backend::Position;
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let pattern = [(1, 0), (0, 1)];
+    /// let pattern = [Position(1, 0), Position(0, 1)];
     /// let target = pattern
     ///     .iter()
     ///     .collect::<RleBuilder>()
@@ -241,8 +244,9 @@ where
     ///
     /// ```compile_fail
     /// use life_backend::format::RleBuilder;
+    /// use life_backend::Position;
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let pattern = [(1, 0), (0, 1)];
+    /// let pattern = [Position(1, 0), Position(0, 1)];
     /// let target = pattern
     ///     .iter()
     ///     .collect::<RleBuilder>()
@@ -260,8 +264,9 @@ where
     ///
     /// ```should_panic
     /// use life_backend::format::RleBuilder;
+    /// use life_backend::Position;
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let pattern = [(1, 0), (0, 1)];
+    /// let pattern = [Position(1, 0), Position(0, 1)];
     /// let target = pattern
     ///     .iter()
     ///     .collect::<RleBuilder>()
@@ -299,8 +304,9 @@ where
     ///
     /// ```
     /// use life_backend::format::RleBuilder;
+    /// use life_backend::Position;
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let pattern = [(1, 0), (0, 1)];
+    /// let pattern = [Position(1, 0), Position(0, 1)];
     /// let target = pattern
     ///     .iter()
     ///     .collect::<RleBuilder>()
@@ -320,8 +326,9 @@ where
     ///
     /// ```compile_fail
     /// use life_backend::format::RleBuilder;
+    /// use life_backend::Position;
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let pattern = [(1, 0), (0, 1)];
+    /// let pattern = [Position(1, 0), Position(0, 1)];
     /// let target = pattern
     ///     .iter()
     ///     .collect::<RleBuilder>()
@@ -360,8 +367,9 @@ where
     ///
     /// ```
     /// use life_backend::format::RleBuilder;
+    /// use life_backend::Position;
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let pattern = [(1, 0), (0, 1)];
+    /// let pattern = [Position(1, 0), Position(0, 1)];
     /// let target = pattern
     ///     .iter()
     ///     .collect::<RleBuilder>()
@@ -382,8 +390,9 @@ where
     ///
     /// ```compile_fail
     /// use life_backend::format::RleBuilder;
+    /// use life_backend::Position;
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let pattern = [(1, 0), (0, 1)];
+    /// let pattern = [Position(1, 0), Position(0, 1)];
     /// let target = pattern
     ///     .iter()
     ///     .collect::<RleBuilder>()
@@ -418,9 +427,9 @@ where
     ///
     /// ```
     /// use life_backend::format::RleBuilder;
-    /// use life_backend::Rule;
+    /// use life_backend::{Position, Rule};
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let pattern = [(1, 0), (0, 1)];
+    /// let pattern = [Position(1, 0), Position(0, 1)];
     /// let target = pattern
     ///     .iter()
     ///     .collect::<RleBuilder>()
@@ -439,9 +448,9 @@ where
     ///
     /// ```compile_fail
     /// use life_backend::format::RleBuilder;
-    /// use life_backend::Rule;
+    /// use life_backend::{Position, Rule};
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let pattern = [(1, 0), (0, 1)];
+    /// let pattern = [Position(1, 0), Position(0, 1)];
     /// let target = pattern
     ///     .iter()
     ///     .collect::<RleBuilder>()
@@ -470,7 +479,7 @@ impl RleBuilder<RleBuilderNoName, RleBuilderNoCreated, RleBuilderNoComment, RleB
     // Implementation of from_iter
     fn from_iter<T>(iter: T) -> Self
     where
-        T: IntoIterator<Item = (usize, usize)>,
+        T: IntoIterator<Item = Position<usize>>,
     {
         let contents = iter.into_iter().collect();
         Self {
@@ -483,15 +492,18 @@ impl RleBuilder<RleBuilderNoName, RleBuilderNoCreated, RleBuilderNoComment, RleB
     }
 }
 
-impl<'a> FromIterator<&'a (usize, usize)> for RleBuilder<RleBuilderNoName, RleBuilderNoCreated, RleBuilderNoComment, RleBuilderNoRule> {
-    /// Creates a value from a non-owning iterator over a series of `&(usize, usize)`.
+impl<'a> FromIterator<&'a Position<usize>> for RleBuilder<RleBuilderNoName, RleBuilderNoCreated, RleBuilderNoComment, RleBuilderNoRule> {
+    /// Creates a value from a non-owning iterator over a series of [`&Position<usize>`].
     /// Each item in the series represents an immutable reference of a live cell position.
+    ///
+    /// [`&Position<usize>`]: Position
     ///
     /// # Examples
     ///
     /// ```
     /// use life_backend::format::RleBuilder;
-    /// let pattern = [(1, 0), (0, 1)];
+    /// use life_backend::Position;
+    /// let pattern = [Position(1, 0), Position(0, 1)];
     /// let iter = pattern.iter();
     /// let builder: RleBuilder = iter.collect();
     /// ```
@@ -499,21 +511,24 @@ impl<'a> FromIterator<&'a (usize, usize)> for RleBuilder<RleBuilderNoName, RleBu
     #[inline]
     fn from_iter<T>(iter: T) -> Self
     where
-        T: IntoIterator<Item = &'a (usize, usize)>,
+        T: IntoIterator<Item = &'a Position<usize>>,
     {
         Self::from_iter(iter.into_iter().copied())
     }
 }
 
-impl FromIterator<(usize, usize)> for RleBuilder<RleBuilderNoName, RleBuilderNoCreated, RleBuilderNoComment, RleBuilderNoRule> {
-    /// Creates a value from an owning iterator over a series of `(usize, usize)`.
+impl FromIterator<Position<usize>> for RleBuilder<RleBuilderNoName, RleBuilderNoCreated, RleBuilderNoComment, RleBuilderNoRule> {
+    /// Creates a value from an owning iterator over a series of [`Position<usize>`].
     /// Each item in the series represents a moved live cell position.
+    ///
+    /// [`Position<usize>`]: Position
     ///
     /// # Examples
     ///
     /// ```
     /// use life_backend::format::RleBuilder;
-    /// let pattern = [(1, 0), (0, 1)];
+    /// use life_backend::Position;
+    /// let pattern = [Position(1, 0), Position(0, 1)];
     /// let iter = pattern.into_iter();
     /// let builder: RleBuilder = iter.collect();
     /// ```
@@ -521,7 +536,7 @@ impl FromIterator<(usize, usize)> for RleBuilder<RleBuilderNoName, RleBuilderNoC
     #[inline]
     fn from_iter<T>(iter: T) -> Self
     where
-        T: IntoIterator<Item = (usize, usize)>,
+        T: IntoIterator<Item = Position<usize>>,
     {
         Self::from_iter(iter)
     }

--- a/src/format/rle/builder.rs
+++ b/src/format/rle/builder.rs
@@ -112,7 +112,9 @@ where
     Comment: RleBuilderComment,
     RuleSpec: RleBuilderRule,
 {
-    /// Builds the specified Rle value.
+    /// Builds the [`Rle`] value.
+    ///
+    /// [`Rle`]: Rle
     ///
     /// # Examples
     ///
@@ -233,7 +235,9 @@ where
     ///
     /// # Errors
     ///
-    /// Code that calls name() twice or more will fail at compile time.  For example:
+    /// Code that calls [`name()`] twice or more will fail at compile time.  For example:
+    ///
+    /// [`name()`]: #method.name
     ///
     /// ```compile_fail
     /// use life_backend::format::RleBuilder;
@@ -249,7 +253,10 @@ where
     /// # }
     /// ```
     ///
-    /// build() returns an error if the string passed by name(str) includes multiple lines.  For example:
+    /// [`build()`] returns an error if the string passed by [`name()`] includes multiple lines.  For example:
+    ///
+    /// [`build()`]: #method.build
+    /// [`name()`]: #method.name
     ///
     /// ```should_panic
     /// use life_backend::format::RleBuilder;
@@ -282,7 +289,11 @@ where
     Comment: RleBuilderComment,
     Rule: RleBuilderRule,
 {
-    /// Set the information when and by whom the pattern was created. If the argument includes newlines, the instance of Rle built by build() includes multiple comment lines.
+    /// Set the information when and by whom the pattern was created.
+    /// If the argument includes newlines, the instance of [`Rle`] built by [`build()`] includes multiple comment lines.
+    ///
+    /// [`Rle`]: Rle
+    /// [`build()`]: #method.build
     ///
     /// # Examples
     ///
@@ -303,7 +314,9 @@ where
     ///
     /// # Errors
     ///
-    /// Code that calls created() twice or more will fail at compile time.  For example:
+    /// Code that calls [`created()`] twice or more will fail at compile time.  For example:
+    ///
+    /// [`created()`]: #method.created
     ///
     /// ```compile_fail
     /// use life_backend::format::RleBuilder;
@@ -337,7 +350,11 @@ where
     Created: RleBuilderCreated,
     Rule: RleBuilderRule,
 {
-    /// Set the comment. If the argument includes newlines, the instance of Rle built by build() includes multiple comment lines.
+    /// Set the comment.
+    /// If the argument includes newlines, the instance of [`Rle`] built by [`build()`] includes multiple comment lines.
+    ///
+    /// [`Rle`]: Rle
+    /// [`build()`]: #method.build
     ///
     /// # Examples
     ///
@@ -359,7 +376,9 @@ where
     ///
     /// # Errors
     ///
-    /// Code that calls comment() twice or more will fail at compile time.  For example:
+    /// Code that calls [`comment()`] twice or more will fail at compile time.  For example:
+    ///
+    /// [`comment()`]: #method.comment
     ///
     /// ```compile_fail
     /// use life_backend::format::RleBuilder;
@@ -414,7 +433,9 @@ where
     ///
     /// # Errors
     ///
-    /// Code that calls rule() twice or more will fail at compile time.  For example:
+    /// Code that calls [`rule()`] twice or more will fail at compile time.  For example:
+    ///
+    /// [`rule()`]: #method.rule
     ///
     /// ```compile_fail
     /// use life_backend::format::RleBuilder;
@@ -463,7 +484,7 @@ impl RleBuilder<RleBuilderNoName, RleBuilderNoCreated, RleBuilderNoComment, RleB
 }
 
 impl<'a> FromIterator<&'a (usize, usize)> for RleBuilder<RleBuilderNoName, RleBuilderNoCreated, RleBuilderNoComment, RleBuilderNoRule> {
-    /// Conversion from a non-owning iterator over a series of &(usize, usize).
+    /// Conversion from a non-owning iterator over a series of `&(usize, usize)`.
     /// Each item in the series represents an immutable reference of a live cell position.
     ///
     /// # Examples
@@ -485,7 +506,7 @@ impl<'a> FromIterator<&'a (usize, usize)> for RleBuilder<RleBuilderNoName, RleBu
 }
 
 impl FromIterator<(usize, usize)> for RleBuilder<RleBuilderNoName, RleBuilderNoCreated, RleBuilderNoComment, RleBuilderNoRule> {
-    /// Conversion from an owning iterator over a series of (usize, usize).
+    /// Conversion from an owning iterator over a series of `(usize, usize)`.
     /// Each item in the series represents a moved live cell position.
     ///
     /// # Examples

--- a/src/format/rle/builder.rs
+++ b/src/format/rle/builder.rs
@@ -99,10 +99,8 @@ where
     /// use life_backend::format::RleBuilder;
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let pattern = [(1, 0), (0, 1)];
-    /// let target = pattern
-    ///     .iter()
-    ///     .collect::<RleBuilder>()
-    ///     .build()?;
+    /// let builder: RleBuilder = pattern.iter().collect();
+    /// let target = builder.build()?;
     /// # Ok(())
     /// # }
     /// ```
@@ -451,14 +449,9 @@ impl<'a> FromIterator<&'a (usize, usize)> for RleBuilder<RleBuilderNoName, RleBu
     ///
     /// ```
     /// use life_backend::format::RleBuilder;
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let pattern = [(1, 0), (0, 1)];
-    /// let builder = pattern
-    ///     .iter()
-    ///     .collect::<RleBuilder>();
-    /// let target = builder.build()?;
-    /// # Ok(())
-    /// # }
+    /// let iter = pattern.iter();
+    /// let builder: RleBuilder = iter.collect();
     /// ```
     ///
     #[inline]
@@ -478,14 +471,9 @@ impl FromIterator<(usize, usize)> for RleBuilder<RleBuilderNoName, RleBuilderNoC
     ///
     /// ```
     /// use life_backend::format::RleBuilder;
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let pattern = [(1, 0), (0, 1)];
-    /// let builder = pattern
-    ///     .into_iter()
-    ///     .collect::<RleBuilder>();
-    /// let target = builder.build()?;
-    /// # Ok(())
-    /// # }
+    /// let iter = pattern.into_iter();
+    /// let builder: RleBuilder = iter.collect();
     /// ```
     ///
     #[inline]

--- a/src/format/rle/builder.rs
+++ b/src/format/rle/builder.rs
@@ -426,6 +426,23 @@ where
 
 // Trait implementations
 
+impl RleBuilder<RleBuilderNoName, RleBuilderNoCreated, RleBuilderNoComment, RleBuilderNoRule> {
+    // Implementation of from_iter
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = (usize, usize)>,
+    {
+        let contents = iter.into_iter().collect();
+        Self {
+            name: RleBuilderNoName,
+            created: RleBuilderNoCreated,
+            comment: RleBuilderNoComment,
+            rule: RleBuilderNoRule,
+            contents,
+        }
+    }
+}
+
 impl<'a> FromIterator<&'a (usize, usize)> for RleBuilder<RleBuilderNoName, RleBuilderNoCreated, RleBuilderNoComment, RleBuilderNoRule> {
     /// Conversion from a non-owning iterator over a series of &(usize, usize).
     /// Each item in the series represents an immutable reference of a live cell position.
@@ -444,18 +461,12 @@ impl<'a> FromIterator<&'a (usize, usize)> for RleBuilder<RleBuilderNoName, RleBu
     /// # }
     /// ```
     ///
+    #[inline]
     fn from_iter<T>(iter: T) -> Self
     where
         T: IntoIterator<Item = &'a (usize, usize)>,
     {
-        let contents = iter.into_iter().copied().collect();
-        Self {
-            name: RleBuilderNoName,
-            created: RleBuilderNoCreated,
-            comment: RleBuilderNoComment,
-            rule: RleBuilderNoRule,
-            contents,
-        }
+        Self::from_iter(iter.into_iter().copied())
     }
 }
 
@@ -477,17 +488,11 @@ impl FromIterator<(usize, usize)> for RleBuilder<RleBuilderNoName, RleBuilderNoC
     /// # }
     /// ```
     ///
+    #[inline]
     fn from_iter<T>(iter: T) -> Self
     where
         T: IntoIterator<Item = (usize, usize)>,
     {
-        let contents = iter.into_iter().collect();
-        Self {
-            name: RleBuilderNoName,
-            created: RleBuilderNoCreated,
-            comment: RleBuilderNoComment,
-            rule: RleBuilderNoRule,
-            contents,
-        }
+        Self::from_iter(iter)
     }
 }

--- a/src/format/rle/core.rs
+++ b/src/format/rle/core.rs
@@ -108,7 +108,7 @@ impl Rle {
     ///     3o$bo!\n\
     /// ";
     /// let parser = Rle::new(pattern.as_bytes())?;
-    /// assert_eq!(*parser.rule(), Rule::conways_life());
+    /// assert_eq!(parser.rule(), &Rule::conways_life());
     /// # Ok(())
     /// # }
     /// ```
@@ -155,12 +155,7 @@ impl Rle {
     ///     3o$bo!\n\
     /// ";
     /// let parser = Rle::new(pattern.as_bytes())?;
-    /// let mut iter = parser.live_cells();
-    /// assert_eq!(iter.next(), Some((0, 0)));
-    /// assert_eq!(iter.next(), Some((1, 0)));
-    /// assert_eq!(iter.next(), Some((2, 0)));
-    /// assert_eq!(iter.next(), Some((1, 1)));
-    /// assert_eq!(iter.next(), None);
+    /// assert!(parser.live_cells().eq([(0, 0), (1, 0), (2, 0), (1, 1)]));
     /// # Ok(())
     /// # }
     /// ```

--- a/src/format/rle/core.rs
+++ b/src/format/rle/core.rs
@@ -21,7 +21,7 @@ use crate::{Format, Rule};
 /// use std::fs::File;
 /// use life_backend::format::Rle;
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let file = File::open(concat!(env!("CARGO_MANIFEST_DIR"), "/patterns/rpentomino.rle"))?;
+/// let file = File::open("patterns/rpentomino.rle")?;
 /// let parser = Rle::new(file)?;
 /// assert!(parser.live_cells().eq([(1, 0), (2, 0), (0, 1), (1, 1), (1, 2)]));
 /// # Ok(())

--- a/src/format/rle/core.rs
+++ b/src/format/rle/core.rs
@@ -142,7 +142,7 @@ impl Rle {
         &self.comments
     }
 
-    /// Creates a non-owning iterator over the series of immutable live cell positions in ascending order.
+    /// Creates an owning iterator over the series of live cell positions in ascending order.
     ///
     /// # Examples
     ///

--- a/src/format/rle/core.rs
+++ b/src/format/rle/core.rs
@@ -67,7 +67,7 @@ impl Rle {
     /// ```
     ///
     #[inline]
-    pub fn width(&self) -> usize {
+    pub const fn width(&self) -> usize {
         self.header.width
     }
 
@@ -90,7 +90,7 @@ impl Rle {
     /// ```
     ///
     #[inline]
-    pub fn height(&self) -> usize {
+    pub const fn height(&self) -> usize {
         self.header.height
     }
 
@@ -114,7 +114,7 @@ impl Rle {
     /// ```
     ///
     #[inline]
-    pub fn rule(&self) -> &Rule {
+    pub const fn rule(&self) -> &Rule {
         &self.header.rule
     }
 
@@ -138,7 +138,7 @@ impl Rle {
     /// ```
     ///
     #[inline]
-    pub fn comments(&self) -> &Vec<String> {
+    pub const fn comments(&self) -> &Vec<String> {
         &self.comments
     }
 

--- a/src/format/rle/core.rs
+++ b/src/format/rle/core.rs
@@ -13,6 +13,38 @@ use crate::{Format, Rule};
 /// - [Run Length Encoded - LifeWiki](https://conwaylife.com/wiki/Run_Length_Encoded)
 /// - [Golly Help: File Formats > Extended RLE format](https://golly.sourceforge.net/Help/formats.html#rle)
 ///
+/// # Examples
+///
+/// Parses the given RLE file, and checks live cells included in it:
+///
+/// ```
+/// use std::fs::File;
+/// use std::path::Path;
+/// use life_backend::format::Rle;
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let file = File::open(concat!(env!("CARGO_MANIFEST_DIR"), "/patterns/rpentomino.rle"))?;
+/// let parser = Rle::new(file)?;
+/// assert!(parser.live_cells().eq([(1, 0), (2, 0), (0, 1), (1, 1), (1, 2)]));
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Parses the given string in RLE format:
+///
+/// ```
+/// use life_backend::format::Rle;
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let pattern = "\
+///     #N R-pentomino\n\
+///     x = 3, y = 3\n\
+///     b2o$2o$bo!\n\
+/// ";
+/// let parser = pattern.parse::<Rle>()?;
+/// assert!(parser.live_cells().eq([(1, 0), (2, 0), (0, 1), (1, 1), (1, 2)]));
+/// # Ok(())
+/// # }
+/// ```
+///
 #[derive(Debug, Clone)]
 pub struct Rle {
     pub(super) header: RleHeader,

--- a/src/format/rle/core.rs
+++ b/src/format/rle/core.rs
@@ -23,7 +23,10 @@ pub struct Rle {
 // Inherent methods
 
 impl Rle {
-    /// Creates from the specified implementor of Read, such as File or `&[u8]`.
+    /// Creates from the specified implementor of [`Read`], such as [`File`] or `&[u8]`.
+    ///
+    /// [`Read`]: std::io::Read
+    /// [`File`]: std::fs::File
     ///
     /// # Examples
     ///

--- a/src/format/rle/core.rs
+++ b/src/format/rle/core.rs
@@ -19,7 +19,6 @@ use crate::{Format, Rule};
 ///
 /// ```
 /// use std::fs::File;
-/// use std::path::Path;
 /// use life_backend::format::Rle;
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let file = File::open(concat!(env!("CARGO_MANIFEST_DIR"), "/patterns/rpentomino.rle"))?;

--- a/src/format/rle/parser.rs
+++ b/src/format/rle/parser.rs
@@ -63,7 +63,7 @@ impl RleParser {
                 self.finished = terminated;
             }
         } else if Self::is_comment_line(line) {
-            self.comments.push(line.to_string());
+            self.comments.push(line.to_owned());
         } else {
             let header = Self::parse_header_line(line)?;
             self.header = Some(header);

--- a/src/format/rle/tests.rs
+++ b/src/format/rle/tests.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 
 use super::{Rle, RleBuilder};
-use crate::Rule;
+use crate::{Position, Rule};
 
 const RULE_HIGHLIFE: Rule = Rule::new(
     &[false, false, false, true, false, false, true, false, false],
@@ -330,7 +330,7 @@ fn test_new_trailing_ignored_line() -> Result<()> {
 
 #[test]
 fn test_build() -> Result<()> {
-    let pattern = [(0, 0), (1, 0), (2, 0), (1, 1)];
+    let pattern = [Position(0, 0), Position(1, 0), Position(2, 0), Position(1, 1)];
     let target = pattern.iter().collect::<RleBuilder>().build()?;
     do_check(&target, 3, 2, &Rule::conways_life(), &Vec::new(), &[(0, 0, 3), (1, 1, 1)], None);
     Ok(())
@@ -338,7 +338,7 @@ fn test_build() -> Result<()> {
 
 #[test]
 fn test_build_singleline_name() -> Result<()> {
-    let pattern = [(0, 0)];
+    let pattern = [Position(0, 0)];
     let target = pattern.iter().collect::<RleBuilder>().name("name").build()?;
     do_check(&target, 1, 1, &Rule::conways_life(), &["#N name"], &[(0, 0, 1)], None);
     Ok(())
@@ -346,7 +346,7 @@ fn test_build_singleline_name() -> Result<()> {
 
 #[test]
 fn test_build_blank_name() -> Result<()> {
-    let pattern = [(0, 0)];
+    let pattern = [Position(0, 0)];
     let target = pattern.iter().collect::<RleBuilder>().name("").build()?;
     do_check(&target, 1, 1, &Rule::conways_life(), &["#N"], &[(0, 0, 1)], None);
     Ok(())
@@ -354,14 +354,14 @@ fn test_build_blank_name() -> Result<()> {
 
 #[test]
 fn test_build_multiline_name() {
-    let pattern = [(0, 0)];
+    let pattern = [Position(0, 0)];
     let target = pattern.iter().collect::<RleBuilder>().name("name\nname").build();
     assert!(target.is_err());
 }
 
 #[test]
 fn test_build_created() -> Result<()> {
-    let pattern = [(0, 0)];
+    let pattern = [Position(0, 0)];
     let target = pattern.iter().collect::<RleBuilder>().created("created").build()?;
     do_check(&target, 1, 1, &Rule::conways_life(), &["#O created"], &[(0, 0, 1)], None);
     Ok(())
@@ -369,7 +369,7 @@ fn test_build_created() -> Result<()> {
 
 #[test]
 fn test_build_blank_created() -> Result<()> {
-    let pattern = [(0, 0)];
+    let pattern = [Position(0, 0)];
     let target = pattern.iter().collect::<RleBuilder>().created("").build()?;
     do_check(&target, 1, 1, &Rule::conways_life(), &["#O"], &[(0, 0, 1)], None);
     Ok(())
@@ -377,7 +377,7 @@ fn test_build_blank_created() -> Result<()> {
 
 #[test]
 fn test_build_createds() -> Result<()> {
-    let pattern = [(0, 0)];
+    let pattern = [Position(0, 0)];
     let target = pattern.iter().collect::<RleBuilder>().created("created0\ncreated1").build()?;
     do_check(&target, 1, 1, &Rule::conways_life(), &["#O created0", "#O created1"], &[(0, 0, 1)], None);
     Ok(())
@@ -385,7 +385,7 @@ fn test_build_createds() -> Result<()> {
 
 #[test]
 fn test_build_comment() -> Result<()> {
-    let pattern = [(0, 0)];
+    let pattern = [Position(0, 0)];
     let target = pattern.iter().collect::<RleBuilder>().comment("comment").build()?;
     do_check(&target, 1, 1, &Rule::conways_life(), &["#C comment"], &[(0, 0, 1)], None);
     Ok(())
@@ -393,7 +393,7 @@ fn test_build_comment() -> Result<()> {
 
 #[test]
 fn test_build_blank_comment() -> Result<()> {
-    let pattern = [(0, 0)];
+    let pattern = [Position(0, 0)];
     let target = pattern.iter().collect::<RleBuilder>().comment("").build()?;
     do_check(&target, 1, 1, &Rule::conways_life(), &["#C"], &[(0, 0, 1)], None);
     Ok(())
@@ -401,7 +401,7 @@ fn test_build_blank_comment() -> Result<()> {
 
 #[test]
 fn test_build_comments() -> Result<()> {
-    let pattern = [(0, 0)];
+    let pattern = [Position(0, 0)];
     let target = pattern.iter().collect::<RleBuilder>().comment("comment0\ncomment1").build()?;
     do_check(&target, 1, 1, &Rule::conways_life(), &["#C comment0", "#C comment1"], &[(0, 0, 1)], None);
     Ok(())
@@ -409,7 +409,7 @@ fn test_build_comments() -> Result<()> {
 
 #[test]
 fn test_build_rule() -> Result<()> {
-    let pattern = [(0, 0)];
+    let pattern = [Position(0, 0)];
     let target = pattern.iter().collect::<RleBuilder>().rule(RULE_HIGHLIFE.clone()).build()?;
     do_check(&target, 1, 1, &RULE_HIGHLIFE, &Vec::new(), &[(0, 0, 1)], None);
     Ok(())
@@ -417,7 +417,7 @@ fn test_build_rule() -> Result<()> {
 
 #[test]
 fn test_build_name_created_comment() -> Result<()> {
-    let pattern = [(0, 0)];
+    let pattern = [Position(0, 0)];
     let target = pattern
         .iter()
         .collect::<RleBuilder>()

--- a/src/game.rs
+++ b/src/game.rs
@@ -10,6 +10,31 @@ use crate::{Board, Position, Rule};
 type DefaultCoordinateType = i16;
 
 /// A representation of games.
+///
+/// The type parameter `CoordinateType` is used as the type of the x- and y-coordinate values for each cell.
+/// The following operations are supported:
+///
+/// - Constructing from `Rule` and `Board`
+/// - Advancing a generation
+/// - Returning the current state
+///
+/// # Examples
+///
+/// ```
+/// use life_backend::{Board, Game, Position, Rule};
+/// let rule = Rule::conways_life();
+/// let board: Board<_> = [(1, 0), (2, 1), (0, 2), (1, 2), (2, 2)] // Glider pattern
+///     .into_iter()
+///     .map(|(x, y)| Position(x, y))
+///     .collect();
+/// let mut game = Game::new(rule, board);
+/// game.update();
+/// let board = game.board();
+/// let bbox = board.bounding_box();
+/// assert_eq!(bbox.x(), &(0..=2));
+/// assert_eq!(bbox.y(), &(1..=3));
+/// ```
+///
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Game<CoordinateType = DefaultCoordinateType>
 where

--- a/src/game.rs
+++ b/src/game.rs
@@ -6,9 +6,6 @@ use std::ops::{Add, Sub};
 
 use crate::{Board, Position, Rule};
 
-/// The default coordinate type of `Game`.
-type DefaultCoordinateType = i16;
-
 /// A representation of games.
 ///
 /// The type parameter `T` is used as the type of the x- and y-coordinate values for each cell.
@@ -36,7 +33,7 @@ type DefaultCoordinateType = i16;
 /// ```
 ///
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Game<T = DefaultCoordinateType>
+pub struct Game<T>
 where
     T: Eq + Hash,
 {

--- a/src/game.rs
+++ b/src/game.rs
@@ -11,7 +11,7 @@ type DefaultCoordinateType = i16;
 
 /// A representation of games.
 ///
-/// The type parameter `CoordinateType` is used as the type of the x- and y-coordinate values for each cell.
+/// The type parameter `T` is used as the type of the x- and y-coordinate values for each cell.
 /// The following operations are supported:
 ///
 /// - Constructing from `Rule` and `Board`
@@ -36,18 +36,18 @@ type DefaultCoordinateType = i16;
 /// ```
 ///
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Game<CoordinateType = DefaultCoordinateType>
+pub struct Game<T = DefaultCoordinateType>
 where
-    CoordinateType: Eq + Hash,
+    T: Eq + Hash,
 {
     rule: Rule,
-    curr_board: Board<CoordinateType>,
-    prev_board: Board<CoordinateType>,
+    curr_board: Board<T>,
+    prev_board: Board<T>,
 }
 
-impl<CoordinateType> Game<CoordinateType>
+impl<T> Game<T>
 where
-    CoordinateType: Eq + Hash,
+    T: Eq + Hash,
 {
     /// Creates from the specified rule and the board.
     ///
@@ -60,7 +60,7 @@ where
     /// let game = Game::new(rule, board);
     /// ```
     ///
-    pub fn new(rule: Rule, board: Board<CoordinateType>) -> Self {
+    pub fn new(rule: Rule, board: Board<T>) -> Self {
         Self {
             rule,
             curr_board: board,
@@ -105,14 +105,14 @@ where
     /// ```
     ///
     #[inline]
-    pub const fn board(&self) -> &Board<CoordinateType> {
+    pub const fn board(&self) -> &Board<T> {
         &self.curr_board
     }
 
     // Returns the count of live neighbours of the specified position.
-    fn live_neighbour_count(board: &Board<CoordinateType>, position: &Position<CoordinateType>) -> usize
+    fn live_neighbour_count(board: &Board<T>, position: &Position<T>) -> usize
     where
-        CoordinateType: Copy + PartialOrd + Add<Output = CoordinateType> + Sub<Output = CoordinateType> + One + Bounded + ToPrimitive,
+        T: Copy + PartialOrd + Add<Output = T> + Sub<Output = T> + One + Bounded + ToPrimitive,
     {
         position.moore_neighborhood_positions().filter(|pos| board.get(pos)).count()
     }
@@ -138,7 +138,7 @@ where
     ///
     pub fn update(&mut self)
     where
-        CoordinateType: Copy + PartialOrd + Add<Output = CoordinateType> + Sub<Output = CoordinateType> + One + Bounded + ToPrimitive,
+        T: Copy + PartialOrd + Add<Output = T> + Sub<Output = T> + One + Bounded + ToPrimitive,
     {
         mem::swap(&mut self.curr_board, &mut self.prev_board);
         self.curr_board.clear();
@@ -159,9 +159,9 @@ where
     }
 }
 
-impl<CoordinateType> fmt::Display for Game<CoordinateType>
+impl<T> fmt::Display for Game<T>
 where
-    CoordinateType: Eq + Hash + Copy + PartialOrd + Zero + One + ToPrimitive,
+    T: Eq + Hash + Copy + PartialOrd + Zero + One + ToPrimitive,
 {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/game.rs
+++ b/src/game.rs
@@ -6,14 +6,18 @@ use std::ops::{Add, Sub};
 
 use crate::{Board, Position, Rule};
 
-/// A representation of games.
+/// A representation of a game.
 ///
 /// The type parameter `T` is used as the type of the x- and y-coordinate values for each cell.
+///
 /// The following operations are supported:
 ///
-/// - Constructing from `Rule` and `Board`
+/// - Constructing from [`Rule`] and [`Board`]
 /// - Advancing a generation
 /// - Returning the current state
+///
+/// [`Rule`]: Rule
+/// [`Board`]: Board
 ///
 /// # Examples
 ///
@@ -114,7 +118,7 @@ where
         position.moore_neighborhood_positions().filter(|pos| board.get(pos)).count()
     }
 
-    /// Update the state of the game.
+    /// Updates the state of the game.
     ///
     /// # Examples
     ///

--- a/src/game.rs
+++ b/src/game.rs
@@ -31,7 +31,7 @@ where
     /// ```
     /// use life_backend::{Board, Game, Position, Rule};
     /// let rule = Rule::conways_life();
-    /// let board: Board = [Position(1, 0), Position(0, 1)].iter().collect();
+    /// let board: Board<_> = [Position(1, 0), Position(0, 1)].iter().collect();
     /// let game = Game::new(rule, board);
     /// ```
     ///
@@ -50,7 +50,7 @@ where
     /// ```
     /// use life_backend::{Board, Game, Position, Rule};
     /// let rule = Rule::conways_life();
-    /// let board: Board = [Position(1, 0), Position(0, 1)].iter().collect();
+    /// let board: Board<_> = [Position(1, 0), Position(0, 1)].iter().collect();
     /// let game = Game::new(rule.clone(), board);
     /// assert_eq!(game.rule(), &rule);
     /// ```
@@ -67,7 +67,7 @@ where
     /// ```
     /// use life_backend::{Board, Game, Position, Rule};
     /// let rule = Rule::conways_life();
-    /// let board: Board = [Position(1, 0), Position(0, 1)].iter().collect();
+    /// let board: Board<_> = [Position(1, 0), Position(0, 1)].iter().collect();
     /// let game = Game::new(rule, board);
     /// let board = game.board();
     /// let bbox = board.bounding_box();
@@ -99,7 +99,7 @@ where
     /// ```
     /// use life_backend::{Board, Game, Position, Rule};
     /// let rule = Rule::conways_life();
-    /// let board: Board = [Position(0, 1), Position(1, 1), Position(2, 1)].iter().collect(); // Blinker pattern
+    /// let board: Board<_> = [Position(0, 1), Position(1, 1), Position(2, 1)].iter().collect(); // Blinker pattern
     /// let mut game = Game::new(rule, board);
     /// game.update();
     /// let board = game.board();

--- a/src/game.rs
+++ b/src/game.rs
@@ -56,7 +56,7 @@ where
     /// ```
     ///
     #[inline]
-    pub fn rule(&self) -> &Rule {
+    pub const fn rule(&self) -> &Rule {
         &self.rule
     }
 
@@ -78,7 +78,7 @@ where
     /// ```
     ///
     #[inline]
-    pub fn board(&self) -> &Board<CoordinateType> {
+    pub const fn board(&self) -> &Board<CoordinateType> {
         &self.curr_board
     }
 

--- a/src/position.rs
+++ b/src/position.rs
@@ -6,7 +6,8 @@ use std::ops::{Add, Sub};
 
 /// A position of a cell.
 ///
-/// `Position<T>` is a tuple `(T, T)`. The first field is the x-coordinate value of the position and the second field is the y-coordinaate value of the potition.
+/// `Position<T>` is a tuple `(T, T)`.
+/// The first field is the x-coordinate value of the position and the second field is the y-coordinate value of the potition.
 /// The type parameter `T` is used as the type of the x- and y-coordinate values of positions.
 ///
 /// # Examples
@@ -24,7 +25,8 @@ use std::ops::{Add, Sub};
 pub struct Position<T>(pub T, pub T);
 
 impl<T> Position<T> {
-    /// Creates an iterator over neighbour positions of the self, defined as [Moore neighbourhood](https://conwaylife.com/wiki/Moore_neighbourhood).
+    /// Creates an owning iterator over neighbour positions of the self position in arbitrary order.
+    /// The neighbour positions are defined in [Moore neighbourhood](https://conwaylife.com/wiki/Moore_neighbourhood).
     ///
     /// # Examples
     ///

--- a/src/position.rs
+++ b/src/position.rs
@@ -9,7 +9,7 @@ use std::ops::{Add, Sub};
 pub struct Position<T>(pub T, pub T);
 
 impl<T> Position<T> {
-    /// Creates an iterator over neighbour positions of the self, defined as Moore neighbourhood.
+    /// Creates an iterator over neighbour positions of the self, defined as [Moore neighbourhood](https://conwaylife.com/wiki/Moore_neighbourhood).
     ///
     /// # Examples
     ///

--- a/src/position.rs
+++ b/src/position.rs
@@ -1,5 +1,6 @@
 use num_iter::range_inclusive;
 use num_traits::{Bounded, One, ToPrimitive};
+use std::fmt;
 use std::hash::Hash;
 use std::ops::{Add, Sub};
 
@@ -41,5 +42,25 @@ impl<T> Position<T> {
         range_inclusive(y_start, y_stop)
             .flat_map(move |v| range_inclusive(x_start, x_stop).map(move |u| Position(u, v)))
             .filter(move |&pos| pos != Position(x, y))
+    }
+}
+
+impl<T> fmt::Display for Position<T>
+where
+    T: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "({}, {})", self.0, self.1)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_display() {
+        let target = Position(1, 2);
+        assert_eq!(format!("{target}"), "(1, 2)".to_string());
     }
 }

--- a/src/position.rs
+++ b/src/position.rs
@@ -31,8 +31,8 @@ impl<T> Position<T> {
     /// # Examples
     ///
     /// ```
-    /// use life_backend::Position;
     /// use std::collections::HashSet;
+    /// use life_backend::Position;
     /// let pos = Position(2, 3);
     /// let result: HashSet<_> = pos
     ///     .moore_neighborhood_positions()

--- a/src/position.rs
+++ b/src/position.rs
@@ -5,6 +5,21 @@ use std::hash::Hash;
 use std::ops::{Add, Sub};
 
 /// A position of a cell.
+///
+/// `Position<T>` is a tuple `(T, T)`. The first field is the x-coordinate value of the position and the second field is the y-coordinaate value of the potition.
+/// The type parameter `T` is used as the type of the x- and y-coordinate values of positions.
+///
+/// # Examples
+///
+/// ```
+/// use life_backend::Position;
+/// let pos = Position(2, 3);
+/// let pos_x = pos.0;
+/// let pos_y = pos.1;
+/// assert_eq!(pos_x, 2);
+/// assert_eq!(pos_y, 3);
+/// ```
+///
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Position<T>(pub T, pub T);
 

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -4,17 +4,21 @@ use std::str::FromStr;
 
 const TRUTH_TABLE_SIZE: usize = 9;
 
-/// A representation of the rules of [Life-like cellular automatons](https://conwaylife.com/wiki/Life-like_cellular_automaton).
+/// A representation of a rule of [Life-like cellular automaton](https://conwaylife.com/wiki/Life-like_cellular_automaton).
 ///
 /// The following operations are supported:
 ///
 /// - Constructing from a pair of truth tables
-/// - Parsing a string into a value of this type, ex. "B3/S23". The following notations are supported, see [Rulestring](https://conwaylife.com/wiki/Rulestring):
-///   - The birth/survival notation (ex. "B3/S23"). Lowercase "b" or "s" are also allowed in the notation instead of "B" or "S"
-///   - S/B notation (ex. "23/3")
+/// - Parsing a string into a value of this type, ex. `"B3/S23"`.
+///   The following notations are supported, see [Rulestring](https://conwaylife.com/wiki/Rulestring):
+///   - The birth/survival notation (ex. `"B3/S23"`). Lowercase `'b'` or `'s'` are also allowed in the notation instead of `'B'` or `'S'`
+///   - S/B notation (ex. `"23/3"`)
 /// - Determining whether a new cell will be born from the specified number of alive neighbors
 /// - Determining whether a cell surrounded by the specified number of alive neighbors will survive
-/// - Converting into a String value, ex. "B3/S23". This operation only supports the birth/survival notation
+/// - Converting into a [`String`] value, ex. `"B3/S23"`.
+///   This operation only supports the birth/survival notation
+///
+/// [`String`]: std::string::String
 ///
 /// # Examples
 ///

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -136,17 +136,23 @@ impl Rule {
 
 impl fmt::Display for Rule {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fn count_slice_numbers(slice: &[bool]) -> usize {
+            slice.iter().filter(|x| **x).count()
+        }
         fn convert_slice_to_string(slice: &[bool]) -> String {
             slice
                 .iter()
                 .enumerate()
                 .filter_map(|(i, &x)| if x { Some(i) } else { None })
-                .map(|n| n.to_string())
-                .collect::<Vec<_>>()
-                .join("")
+                .map(|n| char::from_digit(n as u32, TRUTH_TABLE_SIZE as u32).unwrap()) // this unwrap never panic because `n < TRUTH_TABLE_SIZE` is always guaranteed
+                .collect()
         }
-        let s = ["B", &convert_slice_to_string(&self.birth), "/S", &convert_slice_to_string(&self.survival)].join("");
-        f.write_str(&s)?;
+        let mut buf = String::with_capacity(count_slice_numbers(&self.birth) + count_slice_numbers(&self.survival));
+        buf += "B";
+        buf += &convert_slice_to_string(&self.birth);
+        buf += "/S";
+        buf += &convert_slice_to_string(&self.survival);
+        f.write_str(&buf)?;
         Ok(())
     }
 }

--- a/tests/format_plaintext.rs
+++ b/tests/format_plaintext.rs
@@ -4,6 +4,7 @@ use std::io::Read;
 use std::path::Path;
 
 use life_backend::format::{Plaintext, PlaintextBuilder};
+use life_backend::Position;
 
 fn do_new_test<R>(read: R, expected_positions: &[(usize, usize)]) -> Result<()>
 where
@@ -36,7 +37,7 @@ fn do_new_test_with_path(input_path_string: &str, expected_positions: &[(usize, 
 fn do_build_test(pattern: &[(usize, usize)], name: Option<String>, comment: Option<String>) -> Result<()> {
     // Create the target with the pattern, the name and the comment
     let target = {
-        let builder = pattern.iter().collect::<PlaintextBuilder>();
+        let builder = pattern.iter().map(|&(x, y)| Position(x, y)).collect::<PlaintextBuilder>();
         match (&name, &comment) {
             (None, None) => builder.build()?,
             (Some(name), None) => builder.name(name).build()?,

--- a/tests/format_plaintext.rs
+++ b/tests/format_plaintext.rs
@@ -79,7 +79,7 @@ fn format_plaintext_new_with_string_test() -> Result<()> {
 
 #[test]
 fn format_plaintext_new_with_file_test() -> Result<()> {
-    let input_path = concat!(env!("CARGO_MANIFEST_DIR"), "/patterns/rpentomino.cells");
+    let input_path = "patterns/rpentomino.cells";
     let expected_positions = vec![(1, 0), (2, 0), (0, 1), (1, 1), (1, 2)];
     do_new_test_with_path(input_path, &expected_positions)
 }

--- a/tests/format_plaintext.rs
+++ b/tests/format_plaintext.rs
@@ -28,9 +28,12 @@ fn do_new_test_with_string(input_string: &str, expected_positions: &[(usize, usi
     do_new_test(input_string.as_bytes(), expected_positions)
 }
 
-fn do_new_test_with_path(input_path_string: &str, expected_positions: &[(usize, usize)]) -> Result<()> {
-    let path = Path::new(input_path_string);
-    let file = File::open(path).with_context(|| format!("Failed to open \"{}\"", path.display()))?;
+fn do_new_test_with_path<P>(input_path: P, expected_positions: &[(usize, usize)]) -> Result<()>
+where
+    P: AsRef<Path>,
+{
+    let input_path_for_display = input_path.as_ref().to_owned();
+    let file = File::open(input_path).with_context(|| format!("Failed to open \"{}\"", input_path_for_display.display()))?;
     do_new_test(file, expected_positions)
 }
 
@@ -76,9 +79,9 @@ fn format_plaintext_new_with_string_test() -> Result<()> {
 
 #[test]
 fn format_plaintext_new_with_file_test() -> Result<()> {
-    let input_path_string = concat!(env!("CARGO_MANIFEST_DIR"), "/patterns/rpentomino.cells");
+    let input_path = concat!(env!("CARGO_MANIFEST_DIR"), "/patterns/rpentomino.cells");
     let expected_positions = vec![(1, 0), (2, 0), (0, 1), (1, 1), (1, 2)];
-    do_new_test_with_path(input_path_string, &expected_positions)
+    do_new_test_with_path(input_path, &expected_positions)
 }
 
 #[test]

--- a/tests/format_rle.rs
+++ b/tests/format_rle.rs
@@ -27,9 +27,12 @@ fn do_new_test_with_string(input_string: &str, expected_positions: &[(usize, usi
     do_new_test(input_string.as_bytes(), expected_positions)
 }
 
-fn do_new_test_with_path(input_path_string: &str, expected_positions: &[(usize, usize)]) -> Result<()> {
-    let path = Path::new(input_path_string);
-    let file = File::open(path).with_context(|| format!("Failed to open \"{}\"", path.display()))?;
+fn do_new_test_with_path<P>(input_path: P, expected_positions: &[(usize, usize)]) -> Result<()>
+where
+    P: AsRef<Path>,
+{
+    let input_path_for_display = input_path.as_ref().to_owned();
+    let file = File::open(input_path).with_context(|| format!("Failed to open \"{}\"", input_path_for_display.display()))?;
     do_new_test(file, expected_positions)
 }
 
@@ -81,9 +84,9 @@ fn format_rle_new_with_string_test() -> Result<()> {
 
 #[test]
 fn format_rle_new_with_file_test() -> Result<()> {
-    let input_path_string = concat!(env!("CARGO_MANIFEST_DIR"), "/patterns/rpentomino.rle");
+    let input_path = concat!(env!("CARGO_MANIFEST_DIR"), "/patterns/rpentomino.rle");
     let expected_positions = vec![(1, 0), (2, 0), (0, 1), (1, 1), (1, 2)];
-    do_new_test_with_path(input_path_string, &expected_positions)
+    do_new_test_with_path(input_path, &expected_positions)
 }
 
 #[test]

--- a/tests/format_rle.rs
+++ b/tests/format_rle.rs
@@ -84,7 +84,7 @@ fn format_rle_new_with_string_test() -> Result<()> {
 
 #[test]
 fn format_rle_new_with_file_test() -> Result<()> {
-    let input_path = concat!(env!("CARGO_MANIFEST_DIR"), "/patterns/rpentomino.rle");
+    let input_path = "patterns/rpentomino.rle";
     let expected_positions = vec![(1, 0), (2, 0), (0, 1), (1, 1), (1, 2)];
     do_new_test_with_path(input_path, &expected_positions)
 }

--- a/tests/format_rle.rs
+++ b/tests/format_rle.rs
@@ -4,7 +4,7 @@ use std::io::Read;
 use std::path::Path;
 
 use life_backend::format::{Rle, RleBuilder};
-use life_backend::Rule;
+use life_backend::{Position, Rule};
 
 fn do_new_test<R>(read: R, expected_positions: &[(usize, usize)]) -> Result<()>
 where
@@ -36,7 +36,7 @@ fn do_new_test_with_path(input_path_string: &str, expected_positions: &[(usize, 
 fn do_build_test(pattern: &[(usize, usize)], name: Option<String>, created: Option<String>, comment: Option<String>, rule: Option<Rule>) -> Result<()> {
     // Create the target with the pattern, the name, the created, the comment and the rule
     let target = {
-        let builder = pattern.iter().collect::<RleBuilder>();
+        let builder = pattern.iter().map(|&(x, y)| Position(x, y)).collect::<RleBuilder>();
         match (name, created, comment, rule) {
             (None, None, None, None) => builder.build()?,
             (Some(name), None, None, None) => builder.name(&name).build()?,

--- a/tests/game.rs
+++ b/tests/game.rs
@@ -173,60 +173,60 @@ macro_rules! create_diehard_test_function {
     };
 }
 
-// Still life tests
+#[rustfmt::skip]
+mod game {
+    use super::*;
 
-create_stilllife_test_function!(game_stilllife_block_test, "patterns/block.rle");
-create_stilllife_test_function!(game_stilllife_boat_test, "patterns/boat.rle");
-create_stilllife_test_function!(game_stilllife_spiral_test, "patterns/spiral.rle");
-create_stilllife_test_function!(game_stilllife_34life_block_test, "patterns/34life_block.rle");
-create_stilllife_test_function!(game_stilllife_34life_36bitfortress_test, "patterns/34life_36bitfortress.rle");
+    // Still life tests
+    create_stilllife_test_function!(stilllife_block_test, "patterns/block.rle");
+    create_stilllife_test_function!(stilllife_boat_test, "patterns/boat.rle");
+    create_stilllife_test_function!(stilllife_spiral_test, "patterns/spiral.rle");
+    create_stilllife_test_function!(stilllife_34life_block_test, "patterns/34life_block.rle");
+    create_stilllife_test_function!(stilllife_34life_36bitfortress_test, "patterns/34life_36bitfortress.rle");
 
-// Oscillator tests
+    // Oscillator tests
+    create_oscillator_test_function!(oscillator_blinker_test, "patterns/blinker.rle", 2);
+    create_oscillator_test_function!(oscillator_toad_test, "patterns/toad.rle", 2);
+    create_oscillator_test_function!(oscillator_koksgalaxy_test, "patterns/koksgalaxy.rle", 8);
+    create_oscillator_test_function!(oscillator_pentadecathlon_test, "patterns/pentadecathlon.rle", 15);
+    create_oscillator_test_function!(oscillator_queenbeeshuttle_test, "patterns/transqueenbeeshuttle.rle", 30);
+    create_oscillator_test_function!(oscillator_twinbeesshuttle_test, "patterns/3blocktwinbeesshuttle.rle", 46);
+    create_oscillator_test_function!(oscillator_p60glidershuttle_test, "patterns/p60glidershuttle.rle", 60);
+    create_oscillator_test_function!(oscillator_centinal_test, "patterns/centinal.rle", 100);
+    create_oscillator_test_function!(oscillator_highlife_p7_test, "patterns/highlife_p7.rle", 7);
+    create_oscillator_test_function!(oscillator_highlife_p10_test, "patterns/highlife_p10.rle", 10);
+    create_oscillator_test_function!(oscillator_seeds_duoplet_test, "patterns/seeds_duoplet.rle", 2);
+    create_oscillator_test_function!(oscillator_seeds_anchor_test, "patterns/seeds_anchor.rle", 4);
+    create_oscillator_test_function!(oscillator_34life_z_test, "patterns/34life_z.rle", 2);
+    create_oscillator_test_function!(oscillator_34life_loaf_test, "patterns/34life_loaf.rle", 12);
+    create_oscillator_test_function!(oscillator_2x2_largedomino_test, "patterns/2x2_largedomino.rle", 2);
+    create_oscillator_test_function!(oscillator_2x2_largetetromino_test, "patterns/2x2_largetetromino.rle", 6);
 
-create_oscillator_test_function!(game_oscillator_blinker_test, "patterns/blinker.rle", 2);
-create_oscillator_test_function!(game_oscillator_toad_test, "patterns/toad.rle", 2);
-create_oscillator_test_function!(game_oscillator_koksgalaxy_test, "patterns/koksgalaxy.rle", 8);
-create_oscillator_test_function!(game_oscillator_pentadecathlon_test, "patterns/pentadecathlon.rle", 15);
-create_oscillator_test_function!(game_oscillator_queenbeeshuttle_test, "patterns/transqueenbeeshuttle.rle", 30);
-create_oscillator_test_function!(game_oscillator_twinbeesshuttle_test, "patterns/3blocktwinbeesshuttle.rle", 46);
-create_oscillator_test_function!(game_oscillator_p60glidershuttle_test, "patterns/p60glidershuttle.rle", 60);
-create_oscillator_test_function!(game_oscillator_centinal_test, "patterns/centinal.rle", 100);
-create_oscillator_test_function!(game_oscillator_highlife_p7_test, "patterns/highlife_p7.rle", 7);
-create_oscillator_test_function!(game_oscillator_highlife_p10_test, "patterns/highlife_p10.rle", 10);
-create_oscillator_test_function!(game_oscillator_seeds_duoplet_test, "patterns/seeds_duoplet.rle", 2);
-create_oscillator_test_function!(game_oscillator_seeds_anchor_test, "patterns/seeds_anchor.rle", 4);
-create_oscillator_test_function!(game_oscillator_34life_z_test, "patterns/34life_z.rle", 2);
-create_oscillator_test_function!(game_oscillator_34life_loaf_test, "patterns/34life_loaf.rle", 12);
-create_oscillator_test_function!(game_oscillator_2x2_largedomino_test, "patterns/2x2_largedomino.rle", 2);
-create_oscillator_test_function!(game_oscillator_2x2_largetetromino_test, "patterns/2x2_largetetromino.rle", 6);
+    // Spaceship tests
+    create_spaceship_test_function!(spaceship_glider_test, "patterns/glider.rle", 4, (1, 1));
+    create_spaceship_test_function!(spaceship_lwss_test, "patterns/lwss.rle", 4, (-2, 0));
+    create_spaceship_test_function!(spaceship_loafer_test, "patterns/loafer.rle", 7, (-1, 0));
+    create_spaceship_test_function!(spaceship_copperhead_test, "patterns/copperhead.rle", 10, (0, -1));
+    create_spaceship_test_function!(spaceship_highlife_bomber_test, "patterns/highlife_bomber.rle", 48, (8, 8));
+    create_spaceship_test_function!(spaceship_daynight_rocket_test, "patterns/daynight_rocket.rle", 40, (-20, 0));
+    create_spaceship_test_function!(spaceship_seeds_moon_test, "patterns/seeds_moon.rle", 1, (-1, 0));
+    create_spaceship_test_function!(spaceship_34life_glider_test, "patterns/34life_glider.rle", 3, (0, -1));
+    create_spaceship_test_function!(spaceship_2x2_crawler_test, "patterns/2x2_crawler.rle", 8, (1, -1));
 
-// Spaceship tests
+    // Methuselah tests
+    create_methuselah_test_function!(methuselah_rpentomino_test, "patterns/rpentomino.rle", 1103, 116);
+    create_methuselah_test_function!(methuselah_bheptomino_test, "patterns/bheptomino.rle", 148, 28);
+    create_methuselah_test_function!(methuselah_eheptomino_test, "patterns/eheptomino.rle", 343, 52);
+    create_methuselah_test_function!(methuselah_fheptomino_test, "patterns/fheptomino.rle", 437, 61);
+    create_methuselah_test_function!(methuselah_herschel_test, "patterns/herschel.rle", 128, 24);
+    create_methuselah_test_function!(methuselah_piheptomino_test, "patterns/piheptomino.rle", 173, 55);
+    create_methuselah_test_function!(methuselah_century_test, "patterns/century.rle", 103, 15);
+    create_methuselah_test_function!(methuselah_queenbee_test, "patterns/queenbee.rle", 191, 30);
+    create_methuselah_test_function!(methuselah_thunderbird_test, "patterns/thunderbird.rle", 243, 46);
+    create_methuselah_test_function!(methuselah_switchengine_test, "patterns/switchengine.rle", 3911, 842, ignore = "too long for testing");
+    create_methuselah_test_function!(methuselah_acorn_test, "patterns/acorn.rle", 5206, 633, ignore = "too long for testing");
+    create_methuselah_test_function!(methuselah_bunnies_test, "patterns/bunnies.rle", 17332, 1744, ignore = "too long for testing");
 
-create_spaceship_test_function!(game_spaceship_glider_test, "patterns/glider.rle", 4, (1, 1));
-create_spaceship_test_function!(game_spaceship_lwss_test, "patterns/lwss.rle", 4, (-2, 0));
-create_spaceship_test_function!(game_spaceship_loafer_test, "patterns/loafer.rle", 7, (-1, 0));
-create_spaceship_test_function!(game_spaceship_copperhead_test, "patterns/copperhead.rle", 10, (0, -1));
-create_spaceship_test_function!(game_spaceship_highlife_bomber_test, "patterns/highlife_bomber.rle", 48, (8, 8));
-create_spaceship_test_function!(game_spaceship_daynight_rocket_test, "patterns/daynight_rocket.rle", 40, (-20, 0));
-create_spaceship_test_function!(game_spaceship_seeds_moon_test, "patterns/seeds_moon.rle", 1, (-1, 0));
-create_spaceship_test_function!(game_spaceship_34life_glider_test, "patterns/34life_glider.rle", 3, (0, -1));
-create_spaceship_test_function!(game_spaceship_2x2_crawler_test, "patterns/2x2_crawler.rle", 8, (1, -1));
-
-// Methuselah tests
-
-create_methuselah_test_function!(game_methuselah_rpentomino_test, "patterns/rpentomino.rle", 1103, 116);
-create_methuselah_test_function!(game_methuselah_bheptomino_test, "patterns/bheptomino.rle", 148, 28);
-create_methuselah_test_function!(game_methuselah_eheptomino_test, "patterns/eheptomino.rle", 343, 52);
-create_methuselah_test_function!(game_methuselah_fheptomino_test, "patterns/fheptomino.rle", 437, 61);
-create_methuselah_test_function!(game_methuselah_herschel_test, "patterns/herschel.rle", 128, 24);
-create_methuselah_test_function!(game_methuselah_piheptomino_test, "patterns/piheptomino.rle", 173, 55);
-create_methuselah_test_function!(game_methuselah_century_test, "patterns/century.rle", 103, 15);
-create_methuselah_test_function!(game_methuselah_queenbee_test, "patterns/queenbee.rle", 191, 30);
-create_methuselah_test_function!(game_methuselah_thunderbird_test, "patterns/thunderbird.rle", 243, 46);
-create_methuselah_test_function!(game_methuselah_switchengine_test, "patterns/switchengine.rle", 3911, 842, ignore = "too long for testing");
-create_methuselah_test_function!(game_methuselah_acorn_test, "patterns/acorn.rle", 5206, 633, ignore = "too long for testing");
-create_methuselah_test_function!(game_methuselah_bunnies_test, "patterns/bunnies.rle", 17332, 1744, ignore = "too long for testing");
-
-// Diehard tests
-
-create_diehard_test_function!(game_diehard_diehard_test, "patterns/diehard.rle", 130);
+    // Diehard tests
+    create_diehard_test_function!(diehard_diehard_test, "patterns/diehard.rle", 130);
+}

--- a/tests/game.rs
+++ b/tests/game.rs
@@ -119,7 +119,7 @@ macro_rules! create_stilllife_test_function {
     ($function_name:ident, $relative_path_string:literal) => {
         #[test]
         fn $function_name() -> Result<()> {
-            let path = concat!(env!("CARGO_MANIFEST_DIR"), "/", $relative_path_string);
+            let path = $relative_path_string;
             do_stilllife_test(path)
         }
     };
@@ -129,7 +129,7 @@ macro_rules! create_oscillator_test_function {
     ($function_name:ident, $relative_path_string:literal, $period:expr) => {
         #[test]
         fn $function_name() -> Result<()> {
-            let path = concat!(env!("CARGO_MANIFEST_DIR"), "/", $relative_path_string);
+            let path = $relative_path_string;
             do_oscillator_test(path, $period)
         }
     };
@@ -139,7 +139,7 @@ macro_rules! create_spaceship_test_function {
     ($function_name:ident, $relative_path_string:literal, $period:expr, $relative_position:expr) => {
         #[test]
         fn $function_name() -> Result<()> {
-            let path = concat!(env!("CARGO_MANIFEST_DIR"), "/", $relative_path_string);
+            let path = $relative_path_string;
             do_spaceship_test(path, $period, $relative_position)
         }
     };
@@ -149,7 +149,7 @@ macro_rules! create_methuselah_test_function {
     ($function_name:ident, $relative_path_string:literal, $steps:expr, $expected_final_population:expr) => {
         #[test]
         fn $function_name() -> Result<()> {
-            let path = concat!(env!("CARGO_MANIFEST_DIR"), "/", $relative_path_string);
+            let path = $relative_path_string;
             do_methuselah_test(path, $steps, $expected_final_population)
         }
     };
@@ -157,7 +157,7 @@ macro_rules! create_methuselah_test_function {
         #[test]
         #[ignore = $reason]
         fn $function_name() -> Result<()> {
-            let path = concat!(env!("CARGO_MANIFEST_DIR"), "/", $relative_path_string);
+            let path = $relative_path_string;
             do_methuselah_test(path, $steps, $expected_final_population)
         }
     };
@@ -167,7 +167,7 @@ macro_rules! create_diehard_test_function {
     ($function_name:ident, $relative_path_string:literal, $steps:expr) => {
         #[test]
         fn $function_name() -> Result<()> {
-            let path = concat!(env!("CARGO_MANIFEST_DIR"), "/", $relative_path_string);
+            let path = $relative_path_string;
             do_diehard_test(path, $steps)
         }
     };

--- a/tests/game.rs
+++ b/tests/game.rs
@@ -175,58 +175,58 @@ macro_rules! create_diehard_test_function {
 
 // Still life tests
 
-create_stilllife_test_function!(game_block_test, "patterns/block.rle");
-create_stilllife_test_function!(game_boat_test, "patterns/boat.rle");
-create_stilllife_test_function!(game_spiral_test, "patterns/spiral.rle");
-create_stilllife_test_function!(game_34life_block_test, "patterns/34life_block.rle");
-create_stilllife_test_function!(game_34life_36bitfortress_test, "patterns/34life_36bitfortress.rle");
+create_stilllife_test_function!(game_stilllife_block_test, "patterns/block.rle");
+create_stilllife_test_function!(game_stilllife_boat_test, "patterns/boat.rle");
+create_stilllife_test_function!(game_stilllife_spiral_test, "patterns/spiral.rle");
+create_stilllife_test_function!(game_stilllife_34life_block_test, "patterns/34life_block.rle");
+create_stilllife_test_function!(game_stilllife_34life_36bitfortress_test, "patterns/34life_36bitfortress.rle");
 
 // Oscillator tests
 
-create_oscillator_test_function!(game_blinker_test, "patterns/blinker.rle", 2);
-create_oscillator_test_function!(game_toad_test, "patterns/toad.rle", 2);
-create_oscillator_test_function!(game_koksgalaxy_test, "patterns/koksgalaxy.rle", 8);
-create_oscillator_test_function!(game_pentadecathlon_test, "patterns/pentadecathlon.rle", 15);
-create_oscillator_test_function!(game_queenbeeshuttle_test, "patterns/transqueenbeeshuttle.rle", 30);
-create_oscillator_test_function!(game_twinbeesshuttle_test, "patterns/3blocktwinbeesshuttle.rle", 46);
-create_oscillator_test_function!(game_p60glidershuttle_test, "patterns/p60glidershuttle.rle", 60);
-create_oscillator_test_function!(game_centinal_test, "patterns/centinal.rle", 100);
-create_oscillator_test_function!(game_highlife_p7_test, "patterns/highlife_p7.rle", 7);
-create_oscillator_test_function!(game_highlife_p10_test, "patterns/highlife_p10.rle", 10);
-create_oscillator_test_function!(game_seeds_duoplet_test, "patterns/seeds_duoplet.rle", 2);
-create_oscillator_test_function!(game_seeds_anchor_test, "patterns/seeds_anchor.rle", 4);
-create_oscillator_test_function!(game_34life_z_test, "patterns/34life_z.rle", 2);
-create_oscillator_test_function!(game_34life_loaf_test, "patterns/34life_loaf.rle", 12);
-create_oscillator_test_function!(game_2x2_largedomino_test, "patterns/2x2_largedomino.rle", 2);
-create_oscillator_test_function!(game_2x2_largetetromino_test, "patterns/2x2_largetetromino.rle", 6);
+create_oscillator_test_function!(game_oscillator_blinker_test, "patterns/blinker.rle", 2);
+create_oscillator_test_function!(game_oscillator_toad_test, "patterns/toad.rle", 2);
+create_oscillator_test_function!(game_oscillator_koksgalaxy_test, "patterns/koksgalaxy.rle", 8);
+create_oscillator_test_function!(game_oscillator_pentadecathlon_test, "patterns/pentadecathlon.rle", 15);
+create_oscillator_test_function!(game_oscillator_queenbeeshuttle_test, "patterns/transqueenbeeshuttle.rle", 30);
+create_oscillator_test_function!(game_oscillator_twinbeesshuttle_test, "patterns/3blocktwinbeesshuttle.rle", 46);
+create_oscillator_test_function!(game_oscillator_p60glidershuttle_test, "patterns/p60glidershuttle.rle", 60);
+create_oscillator_test_function!(game_oscillator_centinal_test, "patterns/centinal.rle", 100);
+create_oscillator_test_function!(game_oscillator_highlife_p7_test, "patterns/highlife_p7.rle", 7);
+create_oscillator_test_function!(game_oscillator_highlife_p10_test, "patterns/highlife_p10.rle", 10);
+create_oscillator_test_function!(game_oscillator_seeds_duoplet_test, "patterns/seeds_duoplet.rle", 2);
+create_oscillator_test_function!(game_oscillator_seeds_anchor_test, "patterns/seeds_anchor.rle", 4);
+create_oscillator_test_function!(game_oscillator_34life_z_test, "patterns/34life_z.rle", 2);
+create_oscillator_test_function!(game_oscillator_34life_loaf_test, "patterns/34life_loaf.rle", 12);
+create_oscillator_test_function!(game_oscillator_2x2_largedomino_test, "patterns/2x2_largedomino.rle", 2);
+create_oscillator_test_function!(game_oscillator_2x2_largetetromino_test, "patterns/2x2_largetetromino.rle", 6);
 
 // Spaceship tests
 
-create_spaceship_test_function!(game_glider_test, "patterns/glider.rle", 4, (1, 1));
-create_spaceship_test_function!(game_lwss_test, "patterns/lwss.rle", 4, (-2, 0));
-create_spaceship_test_function!(game_loafer_test, "patterns/loafer.rle", 7, (-1, 0));
-create_spaceship_test_function!(game_copperhead_test, "patterns/copperhead.rle", 10, (0, -1));
-create_spaceship_test_function!(game_highlife_bomber_test, "patterns/highlife_bomber.rle", 48, (8, 8));
-create_spaceship_test_function!(game_daynight_rocket_test, "patterns/daynight_rocket.rle", 40, (-20, 0));
-create_spaceship_test_function!(game_seeds_moon_test, "patterns/seeds_moon.rle", 1, (-1, 0));
-create_spaceship_test_function!(game_34life_glider_test, "patterns/34life_glider.rle", 3, (0, -1));
-create_spaceship_test_function!(game_2x2_crawler_test, "patterns/2x2_crawler.rle", 8, (1, -1));
+create_spaceship_test_function!(game_spaceship_glider_test, "patterns/glider.rle", 4, (1, 1));
+create_spaceship_test_function!(game_spaceship_lwss_test, "patterns/lwss.rle", 4, (-2, 0));
+create_spaceship_test_function!(game_spaceship_loafer_test, "patterns/loafer.rle", 7, (-1, 0));
+create_spaceship_test_function!(game_spaceship_copperhead_test, "patterns/copperhead.rle", 10, (0, -1));
+create_spaceship_test_function!(game_spaceship_highlife_bomber_test, "patterns/highlife_bomber.rle", 48, (8, 8));
+create_spaceship_test_function!(game_spaceship_daynight_rocket_test, "patterns/daynight_rocket.rle", 40, (-20, 0));
+create_spaceship_test_function!(game_spaceship_seeds_moon_test, "patterns/seeds_moon.rle", 1, (-1, 0));
+create_spaceship_test_function!(game_spaceship_34life_glider_test, "patterns/34life_glider.rle", 3, (0, -1));
+create_spaceship_test_function!(game_spaceship_2x2_crawler_test, "patterns/2x2_crawler.rle", 8, (1, -1));
 
 // Methuselah tests
 
-create_methuselah_test_function!(game_rpentomino_test, "patterns/rpentomino.rle", 1103, 116);
-create_methuselah_test_function!(game_bheptomino_test, "patterns/bheptomino.rle", 148, 28);
-create_methuselah_test_function!(game_eheptomino_test, "patterns/eheptomino.rle", 343, 52);
-create_methuselah_test_function!(game_fheptomino_test, "patterns/fheptomino.rle", 437, 61);
-create_methuselah_test_function!(game_herschel_test, "patterns/herschel.rle", 128, 24);
-create_methuselah_test_function!(game_piheptomino_test, "patterns/piheptomino.rle", 173, 55);
-create_methuselah_test_function!(game_century_test, "patterns/century.rle", 103, 15);
-create_methuselah_test_function!(game_queenbee_test, "patterns/queenbee.rle", 191, 30);
-create_methuselah_test_function!(game_thunderbird_test, "patterns/thunderbird.rle", 243, 46);
-create_methuselah_test_function!(game_switchengine_test, "patterns/switchengine.rle", 3911, 842, ignore = "too long for testing");
-create_methuselah_test_function!(game_acorn_test, "patterns/acorn.rle", 5206, 633, ignore = "too long for testing");
-create_methuselah_test_function!(game_bunnies_test, "patterns/bunnies.rle", 17332, 1744, ignore = "too long for testing");
+create_methuselah_test_function!(game_methuselah_rpentomino_test, "patterns/rpentomino.rle", 1103, 116);
+create_methuselah_test_function!(game_methuselah_bheptomino_test, "patterns/bheptomino.rle", 148, 28);
+create_methuselah_test_function!(game_methuselah_eheptomino_test, "patterns/eheptomino.rle", 343, 52);
+create_methuselah_test_function!(game_methuselah_fheptomino_test, "patterns/fheptomino.rle", 437, 61);
+create_methuselah_test_function!(game_methuselah_herschel_test, "patterns/herschel.rle", 128, 24);
+create_methuselah_test_function!(game_methuselah_piheptomino_test, "patterns/piheptomino.rle", 173, 55);
+create_methuselah_test_function!(game_methuselah_century_test, "patterns/century.rle", 103, 15);
+create_methuselah_test_function!(game_methuselah_queenbee_test, "patterns/queenbee.rle", 191, 30);
+create_methuselah_test_function!(game_methuselah_thunderbird_test, "patterns/thunderbird.rle", 243, 46);
+create_methuselah_test_function!(game_methuselah_switchengine_test, "patterns/switchengine.rle", 3911, 842, ignore = "too long for testing");
+create_methuselah_test_function!(game_methuselah_acorn_test, "patterns/acorn.rle", 5206, 633, ignore = "too long for testing");
+create_methuselah_test_function!(game_methuselah_bunnies_test, "patterns/bunnies.rle", 17332, 1744, ignore = "too long for testing");
 
 // Diehard tests
 
-create_diehard_test_function!(game_diehard_test, "patterns/diehard.rle", 130);
+create_diehard_test_function!(game_diehard_diehard_test, "patterns/diehard.rle", 130);


### PR DESCRIPTION
- Features
  - Accept `AsRef<Path>` instead of `Path`
  - Add `Position::fmt()`
  - Remove default type parameters of Board and game
  - Use `Position<usize>` instead of `(usize, usize)` in `format::PlaintextBuilder` and `format::RleBuilder`
  - Add `new()`, `default()` and `extend()` in `format::PlaintextBuilder` and `format::RleBuilder`
- Documentation
  - Add example codes to the types: `Position`, `Game`, `format::
Plaintext`, `format::PlaintextBuilder`, `format::Rle` and `format::RleBuilder`
  - Add links to structs, methods and etc.
- Tests, benchmarks
  - Use oscillator periods instead of fixed numbers in oscillator benchmarks
  - Add methuselah benchmarks
- Implementation
  - Change the implementation of `Board`: struct -> newtype
  - Use `to_owned()` instead of `to_string()`
  - Introduce `#[rustfmt::skip]` for table codes in tests/game.rs and benches/benchmark.rs
  - Remove using `CARGO_MANIFEST_DIR` in codes