### PR TITLE
Refine as code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Lint via Clippy
-      run: cargo clippy --no-deps --all-targets --all-features -- -D warnings
+      run: cargo clippy --no-deps --all-targets --all-features -- --deny warnings
 
   doc:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "life-backend"
 version = "0.1.0"
-edition = "2021"
+edition = "2018"
 license = "MIT OR Apache-2.0"
 
 [dependencies]

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use criterion::{criterion_group, criterion_main, Criterion};
 use num_traits::{Bounded, One, ToPrimitive, Zero};
+use std::convert::TryFrom;
 use std::hash::Hash;
 use std::ops::{Add, Sub};
 use std::path::Path;

--- a/examples/game.rs
+++ b/examples/game.rs
@@ -56,3 +56,17 @@ fn main() -> Result<()> {
     let config = Config::new(env::args())?;
     run(config)
 }
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use std::process::Command;
+    #[test]
+    fn glider() -> Result<()> {
+        let status = Command::new("cargo")
+            .args(["run", "--example", "game", "patterns/glider.rle", "4", "4"])
+            .status()?;
+        assert!(status.success());
+        Ok(())
+    }
+}

--- a/examples/game.rs
+++ b/examples/game.rs
@@ -45,7 +45,7 @@ fn print_game(game: &Game<I>, generation: usize) {
 fn simulate(mut game: Game<I>, generation: usize, step_size: usize) {
     for i in 0..generation {
         if i % step_size == 0 {
-            print_game(&game, generation);
+            print_game(&game, i);
         }
         game.update();
     }

--- a/src/board.rs
+++ b/src/board.rs
@@ -5,6 +5,7 @@ use std::collections::hash_set;
 use std::collections::HashSet;
 use std::fmt;
 use std::hash::Hash;
+use std::iter::FromIterator;
 
 use crate::{BoardRange, Position};
 
@@ -276,7 +277,7 @@ where
     /// let pattern = [Position(1, 0), Position(0, 1)];
     /// let board: Board<i16> = pattern.iter().collect();
     /// let result: HashSet<_> = board.into_iter().collect();
-    /// let expected: HashSet<_> = pattern.into_iter().collect();
+    /// let expected: HashSet<_> = pattern.iter().copied().collect();
     /// assert_eq!(result, expected);
     /// ```
     ///

--- a/src/boardrange.rs
+++ b/src/boardrange.rs
@@ -1,5 +1,6 @@
 use num_traits::{One, Zero};
 use std::fmt;
+use std::iter::FromIterator;
 use std::ops::RangeInclusive;
 
 use crate::Position;

--- a/src/format/plaintext/builder.rs
+++ b/src/format/plaintext/builder.rs
@@ -1,6 +1,7 @@
 use anyhow::{ensure, Result};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
+use std::iter::FromIterator;
 
 use super::{Plaintext, PlaintextLine};
 use crate::Position;

--- a/src/format/plaintext/core.rs
+++ b/src/format/plaintext/core.rs
@@ -153,7 +153,7 @@ impl Plaintext {
     /// ```
     ///
     pub fn live_cells(&self) -> impl Iterator<Item = Position<usize>> + '_ {
-        self.contents.iter().flat_map(|PlaintextLine(y, xs)| xs.iter().map(|x| Position(*x, *y)))
+        self.contents.iter().flat_map(|PlaintextLine(y, xs)| xs.iter().map(move |x| Position(*x, *y)))
     }
 }
 

--- a/src/format/rle/builder.rs
+++ b/src/format/rle/builder.rs
@@ -1,6 +1,7 @@
 use anyhow::{ensure, Result};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
+use std::iter::FromIterator;
 
 use super::{Rle, RleHeader, RleRunsTriple};
 use crate::{Position, Rule};
@@ -187,7 +188,7 @@ where
     ///
     pub fn build(self) -> Result<Rle> {
         let comments: Vec<_> = {
-            fn parse_to_comments(str: Option<String>, prefix: &str) -> Vec<String> {
+            fn parse_to_comments(str: &Option<String>, prefix: &str) -> Vec<String> {
                 fn append_prefix(str: &str, prefix: &str) -> String {
                     let mut buf = prefix.to_owned();
                     if !str.is_empty() {
@@ -212,7 +213,7 @@ where
                 ensure!(str.lines().count() <= 1, "the string passed by name(str) includes multiple lines");
             }
             [(name, "#N"), (self.created.drain(), "#O"), (self.comment.drain(), "#C")]
-                .into_iter()
+                .iter()
                 .flat_map(|(str, prefix)| parse_to_comments(str, prefix).into_iter())
                 .collect()
         };

--- a/src/game.rs
+++ b/src/game.rs
@@ -22,7 +22,8 @@ use crate::{Board, Position, Rule};
 /// use life_backend::{Board, Game, Position, Rule};
 /// let rule = Rule::conways_life();
 /// let board: Board<_> = [(1, 0), (2, 1), (0, 2), (1, 2), (2, 2)] // Glider pattern
-///     .into_iter()
+///     .iter()
+///     .copied()
 ///     .map(|(x, y)| Position(x, y))
 ///     .collect();
 /// let mut game = Game::new(rule, board);
@@ -140,20 +141,22 @@ where
         T: Copy + PartialOrd + Add<Output = T> + Sub<Output = T> + One + Bounded + ToPrimitive,
     {
         mem::swap(&mut self.curr_board, &mut self.prev_board);
+        let prev_board = &self.prev_board;
+        let rule = &self.rule;
         self.curr_board.clear();
         self.curr_board.extend(
             self.prev_board
                 .iter()
                 .flat_map(|pos| pos.moore_neighborhood_positions())
-                .filter(|pos| !self.prev_board.contains(pos)),
+                .filter(|pos| !prev_board.contains(pos)),
         );
         self.curr_board.retain(|pos| {
-            let count = Self::live_neighbour_count(&self.prev_board, pos);
-            self.rule.is_born(count)
+            let count = Self::live_neighbour_count(prev_board, pos);
+            rule.is_born(count)
         });
         self.curr_board.extend(self.prev_board.iter().copied().filter(|pos| {
-            let count = Self::live_neighbour_count(&self.prev_board, pos);
-            self.rule.is_survive(count)
+            let count = Self::live_neighbour_count(prev_board, pos);
+            rule.is_survive(count)
         }));
     }
 }

--- a/src/position.rs
+++ b/src/position.rs
@@ -1,5 +1,6 @@
 use num_iter::range_inclusive;
 use num_traits::{Bounded, One, ToPrimitive};
+use std::convert::TryFrom;
 use std::fmt;
 use std::hash::Hash;
 use std::ops::{Add, Sub};
@@ -86,7 +87,8 @@ impl<T> Position<T> {
     ///     .moore_neighborhood_positions()
     ///     .collect();
     /// let expected: HashSet<_> = [(1, 2), (2, 2), (3, 2), (1, 3), (3, 3), (1, 4), (2, 4), (3, 4)]
-    ///     .into_iter()
+    ///     .iter()
+    ///     .copied()
     ///     .map(|(x, y)| Position(x, y))
     ///     .collect();
     /// assert_eq!(result, expected);
@@ -173,7 +175,8 @@ mod tests {
         assert_eq!(
             result,
             [(-1, -1), (0, -1), (1, -1), (-1, 0), (1, 0), (-1, 1), (0, 1), (1, 1)]
-                .into_iter()
+                .iter()
+                .copied()
                 .map(|(x, y)| Position(x, y))
                 .collect::<HashSet<_>>()
         );


### PR DESCRIPTION
- Extend the Rust edition to be supported: 2021 -> 2018
- Bugfix: generation numbers printed by examples/game.rs
- Add an unit test for examples/game.rs